### PR TITLE
パーサーとテストの改善

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,15 +11,15 @@ repositories {
 
 dependencies {
     // 既存の JAR ファイルを利用
-    implementation files('compilelib/lucene-core-3.5.0.jar')
+    implementation files('lib/6.2.1/lucene-core-6.2.1.jar')
 
     // 圧縮ファイル対応
-    implementation 'org.apache.commons:commons-compress:1.26.1'
+    implementation 'org.apache.commons:commons-compress:1.28.0'
 
     // Apache Parquet
-    implementation 'org.apache.parquet:parquet-hadoop:1.12.3'
-    implementation 'org.apache.hadoop:hadoop-common:3.3.4'
-    implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.3.4'
+    implementation 'org.apache.parquet:parquet-hadoop:1.17.0'
+    implementation 'org.apache.hadoop:hadoop-common:3.4.2'
+    implementation 'org.apache.hadoop:hadoop-mapreduce-client-core:3.4.2'
 
     // テストライブラリ
     testImplementation platform('org.junit:junit-bom:5.10.0')
@@ -33,7 +33,7 @@ java {
     }
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
 }
 
@@ -45,29 +45,34 @@ test {
 tasks.register('runParser', JavaExec) {
     mainClass = 'lucene.gosen.wikipedia.PagesArticlesXmlParser'
     classpath = sourceSets.main.runtimeClasspath
+    systemProperty 'file.encoding', 'UTF-8'
     // 引数が必要な場合は --args="old.jar new.jar" で渡せるように設定
 }
 
 tasks.register('runDownload', JavaExec) {
     mainClass = 'lucene.gosen.wikipedia.WikipediaDownloader'
     classpath = sourceSets.main.runtimeClasspath
+    systemProperty 'file.encoding', 'UTF-8'
     // 引数が必要な場合は --args="url destination" で渡せるように設定
 }
 
 tasks.register('runDownloadJars', JavaExec) {
     mainClass = 'lucene.gosen.wikipedia.MavenJarDownloader'
     classpath = sourceSets.main.runtimeClasspath
+    systemProperty 'file.encoding', 'UTF-8'
     // 引数が必要な場合は --args="version [destination-dir] [classifier]" で渡せるように設定
 }
 
 tasks.register('runWiki40bDownload', JavaExec) {
     mainClass = 'lucene.gosen.wikipedia.Wiki40bDownloader'
     classpath = sourceSets.main.runtimeClasspath
+    systemProperty 'file.encoding', 'UTF-8'
     // 引数が必要な場合は --args="[destination-dir] [TRAIN|VALIDATION|TEST|ALL]" で渡せるように設定
 }
 
 tasks.register('runWiki40bParser', JavaExec) {
     mainClass = 'lucene.gosen.wikipedia.Wiki40bParquetParser'
     classpath = sourceSets.main.runtimeClasspath
+    systemProperty 'file.encoding', 'UTF-8'
     // 引数が必要な場合は --args="old.jar new.jar [parquet-file]" で渡せるように設定
 }

--- a/src/main/java/lucene/gosen/test/util/ComponentContainer.java
+++ b/src/main/java/lucene/gosen/test/util/ComponentContainer.java
@@ -74,7 +74,7 @@ public class ComponentContainer {
   }
   
   /**
-   * TODO 引数にnullが渡せる場合にうまくいかない？コンストラクタ引数のクラス配列は別途与えたほうがいいか？
+   * TODO $B0z?t$K(Bnull$B$,EO$;$k>l9g$K$&$^$/$$$+$J$$!)%3%s%9%H%i%/%?0z?t$N%/%i%9G[Ns$OJLESM?$($?$[$&$,$$$$$+!)(B
    * @param targetClass
    * @param args
    * @return
@@ -87,7 +87,7 @@ public class ComponentContainer {
       Object obj = constructor.newInstance(args);
       return obj;
     }catch(Exception e){
-      throw new RuntimeException("Unable to instantiate target["+targetClass+"]");
+      throw new RuntimeException("Unable to instantiate target["+targetClass+"]", e);
     }
   }
 }

--- a/src/main/java/lucene/gosen/wikipedia/PagesArticlesXmlParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/PagesArticlesXmlParser.java
@@ -94,16 +94,25 @@ public class PagesArticlesXmlParser {
       XMLEventReader reader = factory.createXMLEventReader(is);
       int counter = 0;
       int falseCounter = 0;
+      int skippedCounter = 0;
+      boolean printToConsole = (maxRecordCount > 0 && maxRecordCount <= 10);
+
       while (reader.hasNext()) {
         XMLEvent event = reader.nextEvent();
         if (isStartElem(event, "page")) {
           WikipediaModel model = pageParse(reader);
           if (model != null){
-            oldModelAnalyzer.analyze(model, oldJarContainer, oldResult);
+            int skipped = oldModelAnalyzer.analyze(model, oldJarContainer, oldResult);
             newModelAnalyzer.analyze(model, newJarContainer, newResult);
-            if(compareResult(bw, model, oldResult, newResult)){
+            skippedCounter += skipped;
+            if(compareResult(bw, model, oldResult, newResult, printToConsole)){
               falseCounter++;;
             }
+
+            if (printToConsole) {
+              printResults(counter, model, oldResult, newResult);
+            }
+
             if(counter % 1000 == 0){
               System.out.println("success count:"+counter);
               bw.flush();
@@ -123,6 +132,7 @@ public class PagesArticlesXmlParser {
       bw.close();
       System.out.println("total processed: " + counter);
       System.out.println("falseCounter: " + falseCounter);
+      System.out.println("skippedCounter: " + skippedCounter);
       System.out.println((System.currentTimeMillis() - start) + "msec");
     }
   }
@@ -137,51 +147,93 @@ public class PagesArticlesXmlParser {
     return is;
   }
   
-  private static boolean compareResult(BufferedWriter bw, WikipediaModel model, AnalyzeResult[] oldResult, AnalyzeResult[] newResult)throws IOException{
+  private static boolean compareResult(BufferedWriter bw, WikipediaModel model, AnalyzeResult[] oldResult, AnalyzeResult[] newResult, boolean printToConsole)throws IOException{
 
     boolean different = false;
-    
+
     //size check
     for(int i=0;i<RESULT_SIZE;i++){
       if(oldResult[i].getTotalCost() != newResult[i].getTotalCost()){
-        
-        bw.append("analyze result[cost] is different!!");
+        String msg = "analyze result[cost] is different!!";
+        bw.append(msg);
         bw.newLine();
-        bw.append("  old["+oldResult[i].getTotalCost()+"]");
+        if (printToConsole) System.out.println(msg);
+
+        String oldMsg = "  old["+oldResult[i].getTotalCost()+"]";
+        bw.append(oldMsg);
         bw.newLine();
-        bw.append("  new["+newResult[i].getTotalCost()+"]");
+        if (printToConsole) System.out.println(oldMsg);
+
+        String newMsg = "  new["+newResult[i].getTotalCost()+"]";
+        bw.append(newMsg);
         bw.newLine();
+        if (printToConsole) System.out.println(newMsg);
+
         different = true;
       }
       if(different){
         if(i==0){
           bw.append(model.title);
+          if (printToConsole) System.out.println("Title: " + model.title);
         }else{
           //System.out.println(model.text);
         }
         //System.exit(-1);
       }
       if(!oldResult[i].getTermList().equals(newResult[i].getTermList())){
-        bw.append("analyze result[termList] is different!!");
+        String msg = "analyze result[termList] is different!!";
+        bw.append(msg);
         bw.newLine();
-        bw.append("  old["+oldResult[i].getTermList().toString()+"]");
+        if (printToConsole) System.out.println(msg);
+
+        String oldMsg = "  old["+oldResult[i].getTermList().toString()+"]";
+        bw.append(oldMsg);
         bw.newLine();
-        bw.append("  new["+newResult[i].getTermList().toString()+"]");
+        if (printToConsole) System.out.println(oldMsg);
+
+        String newMsg = "  new["+newResult[i].getTermList().toString()+"]";
+        bw.append(newMsg);
         bw.newLine();
+        if (printToConsole) System.out.println(newMsg);
+
         different = true;
       }
       if(!oldResult[i].getPosList().equals(newResult[i].getPosList())){
-        bw.append("analyze result[posList] is different!!");
+        String msg = "analyze result[posList] is different!!";
+        bw.append(msg);
         bw.newLine();
-        bw.append("  old["+oldResult[i].getPosList().toString()+"]");
+        if (printToConsole) System.out.println(msg);
+
+        String oldMsg = "  old["+oldResult[i].getPosList().toString()+"]";
+        bw.append(oldMsg);
         bw.newLine();
-        bw.append("  new["+newResult[i].getPosList().toString()+"]");
+        if (printToConsole) System.out.println(oldMsg);
+
+        String newMsg = "  new["+newResult[i].getPosList().toString()+"]";
+        bw.append(newMsg);
         bw.newLine();
+        if (printToConsole) System.out.println(newMsg);
+
         different = true;
       }
       break;
     }
     return different;
+  }
+
+  private static void printResults(int counter, WikipediaModel model,
+                                    AnalyzeResult[] oldResult, AnalyzeResult[] newResult) {
+    System.out.println("\n=== Record #" + (counter + 1) + " ===");
+    System.out.println("Title: \"" + model.getTitle() + "\"");
+    System.out.println("Text: \"" + model.getText() + "\"");
+    System.out.println("\n[OLD Results]");
+    System.out.println("  Terms: " + oldResult[0].getTermList());
+    System.out.println("  POS: " + oldResult[0].getPosList());
+    System.out.println("  Total Cost: " + oldResult[0].getTotalCost());
+    System.out.println("\n[NEW Results]");
+    System.out.println("  Terms: " + newResult[0].getTermList());
+    System.out.println("  POS: " + newResult[0].getPosList());
+    System.out.println("  Total Cost: " + newResult[0].getTotalCost());
   }
 
   /** page element内の解析 */

--- a/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
@@ -79,15 +79,22 @@ public class Wiki40bParquetParser {
 
             int counter = 0;
             int falseCounter = 0;
+            int skippedCounter = 0;
             WikipediaModel model;
+            boolean printToConsole = (maxRecordCount > 0 && maxRecordCount <= 10);
 
             while ((model = reader.read()) != null) {
                 if (model.getText() != null && !model.getText().isEmpty()) {
-                    oldModelAnalyzer.analyze(model, oldJarContainer, oldResult);
+                    int skipped = oldModelAnalyzer.analyze(model, oldJarContainer, oldResult);
                     newModelAnalyzer.analyze(model, newJarContainer, newResult);
+                    skippedCounter += skipped;
 
-                    if (compareResult(bw, model, oldResult, newResult)) {
+                    if (compareResult(bw, model, oldResult, newResult, printToConsole)) {
                         falseCounter++;
+                    }
+
+                    if (printToConsole) {
+                        printResults(counter, model, oldResult, newResult);
                     }
 
                     if (counter % 1000 == 0) {
@@ -107,51 +114,95 @@ public class Wiki40bParquetParser {
             bw.close();
             System.out.println("total processed: " + counter);
             System.out.println("falseCounter: " + falseCounter);
+            System.out.println("skippedCounter: " + skippedCounter);
             System.out.println((System.currentTimeMillis() - start) + "msec");
         }
     }
 
     private static boolean compareResult(BufferedWriter bw, WikipediaModel model,
-                                         AnalyzeResult[] oldResult, AnalyzeResult[] newResult) throws IOException {
+                                         AnalyzeResult[] oldResult, AnalyzeResult[] newResult, boolean printToConsole) throws IOException {
         boolean different = false;
 
         // size check
         for (int i = 0; i < RESULT_SIZE; i++) {
             if (oldResult[i].getTotalCost() != newResult[i].getTotalCost()) {
-                bw.append("analyze result[cost] is different!!");
+                String msg = "analyze result[cost] is different!!";
+                bw.append(msg);
                 bw.newLine();
-                bw.append("  old[" + oldResult[i].getTotalCost() + "]");
+                if (printToConsole) System.out.println(msg);
+
+                String oldMsg = "  old[" + oldResult[i].getTotalCost() + "]";
+                bw.append(oldMsg);
                 bw.newLine();
-                bw.append("  new[" + newResult[i].getTotalCost() + "]");
+                if (printToConsole) System.out.println(oldMsg);
+
+                String newMsg = "  new[" + newResult[i].getTotalCost() + "]";
+                bw.append(newMsg);
                 bw.newLine();
+                if (printToConsole) System.out.println(newMsg);
+
                 different = true;
             }
             if (different) {
                 if (i == 0) {
                     bw.append(model.title);
+                    if (printToConsole) System.out.println("Title: " + model.title);
                 }
             }
             if (!oldResult[i].getTermList().equals(newResult[i].getTermList())) {
-                bw.append("analyze result[termList] is different!!");
+                String msg = "analyze result[termList] is different!!";
+                bw.append(msg);
                 bw.newLine();
-                bw.append("  old[" + oldResult[i].getTermList().toString() + "]");
+                if (printToConsole) System.out.println(msg);
+
+                String oldMsg = "  old[" + oldResult[i].getTermList().toString() + "]";
+                bw.append(oldMsg);
                 bw.newLine();
-                bw.append("  new[" + newResult[i].getTermList().toString() + "]");
+                if (printToConsole) System.out.println(oldMsg);
+
+                String newMsg = "  new[" + newResult[i].getTermList().toString() + "]";
+                bw.append(newMsg);
                 bw.newLine();
+                if (printToConsole) System.out.println(newMsg);
+
                 different = true;
             }
             if (!oldResult[i].getPosList().equals(newResult[i].getPosList())) {
-                bw.append("analyze result[posList] is different!!");
+                String msg = "analyze result[posList] is different!!";
+                bw.append(msg);
                 bw.newLine();
-                bw.append("  old[" + oldResult[i].getPosList().toString() + "]");
+                if (printToConsole) System.out.println(msg);
+
+                String oldMsg = "  old[" + oldResult[i].getPosList().toString() + "]";
+                bw.append(oldMsg);
                 bw.newLine();
-                bw.append("  new[" + newResult[i].getPosList().toString() + "]");
+                if (printToConsole) System.out.println(oldMsg);
+
+                String newMsg = "  new[" + newResult[i].getPosList().toString() + "]";
+                bw.append(newMsg);
                 bw.newLine();
+                if (printToConsole) System.out.println(newMsg);
+
                 different = true;
             }
             break;
         }
         return different;
+    }
+
+    private static void printResults(int counter, WikipediaModel model,
+                                      AnalyzeResult[] oldResult, AnalyzeResult[] newResult) {
+        System.out.println("\n=== Record #" + (counter + 1) + " ===");
+        System.out.println("Title: \"" + model.getTitle() + "\"");
+        System.out.println("Text: \"" + model.getText() + "\"");
+        System.out.println("\n[OLD Results]");
+        System.out.println("  Terms: " + oldResult[0].getTermList());
+        System.out.println("  POS: " + oldResult[0].getPosList());
+        System.out.println("  Total Cost: " + oldResult[0].getTotalCost());
+        System.out.println("\n[NEW Results]");
+        System.out.println("  Terms: " + newResult[0].getTermList());
+        System.out.println("  POS: " + newResult[0].getPosList());
+        System.out.println("  Total Cost: " + newResult[0].getTotalCost());
     }
 
     private static File[] getJarFiles(String path) {
@@ -227,7 +278,17 @@ public class Wiki40bParquetParser {
             return new PrimitiveConverter() {
                 @Override
                 public void addBinary(Binary value) {
-                    String str = value.toStringUsingUTF8();
+                    // Try different decoding approaches
+                    String str;
+                    try {
+                        // First, try UTF-8 decoding
+                        byte[] bytes = value.getBytes();
+                        str = new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+                    } catch (Exception e) {
+                        // Fallback to default method
+                        str = value.toStringUsingUTF8();
+                    }
+
                     // フィールドインデックスに基づいてマッピング
                     // Wiki-40Bのスキーマ: wikidata_id, text, version_id
                     switch (fieldIndex) {

--- a/src/main/java/lucene/gosen/wikipedia/analyzer/WikipediaModelAnalyzer.java
+++ b/src/main/java/lucene/gosen/wikipedia/analyzer/WikipediaModelAnalyzer.java
@@ -30,28 +30,55 @@ import org.apache.lucene.util.Attribute;
 
 
 public class WikipediaModelAnalyzer {
-  
-  public void analyze(WikipediaModel model, ComponentContainer container, AnalyzeResult[] result)throws Exception{
-    analyze(container, model.getTitle(), result[0]);
-    analyze(container, model.getText(), result[1]);
+
+  private final String dictionaryDir;
+
+  public WikipediaModelAnalyzer() {
+    this.dictionaryDir = null;
   }
-  
-  private void analyze(ComponentContainer container, String target, AnalyzeResult result) throws NumberFormatException, IllegalArgumentException, SecurityException, IllegalAccessException, InvocationTargetException, NoSuchMethodException{
+
+  public WikipediaModelAnalyzer(String dictionaryDir) {
+    this.dictionaryDir = dictionaryDir;
+  }
+
+  public int analyze(WikipediaModel model, ComponentContainer container, AnalyzeResult[] result)throws Exception{
+    boolean titleSkipped = analyze(container, model.getTitle(), result[0]);
+    boolean textSkipped = analyze(container, model.getText(), result[1]);
+
+    // Only count as skipped if both title and text are empty
+    return (titleSkipped && textSkipped) ? 1 : 0;
+  }
+
+  private boolean analyze(ComponentContainer container, String target, AnalyzeResult result) throws NumberFormatException, IllegalArgumentException, SecurityException, IllegalAccessException, InvocationTargetException, NoSuchMethodException{
     result.reset();
-    
+
+    // Skip empty strings
+    if (target == null || target.isEmpty()) {
+      return true; // skipped
+    }
+
     StringReader reader = new StringReader(target);
 
     try{
-      Tokenizer tokenizer = (Tokenizer)container.createComponent("org.apache.lucene.analysis.gosen.GosenTokenizer", new Class[]{Reader.class} ,new Object[]{reader});
+      // Load StreamFilter class
+      Class<?> streamFilterClass = container.loadComponent("net.java.sen.filter.StreamFilter");
+
+      // GosenTokenizer requires: StreamFilter filter, String dictionaryDir, boolean tokenizeUnknownKatakana
+      Tokenizer tokenizer = (Tokenizer)container.createComponent("org.apache.lucene.analysis.gosen.GosenTokenizer",
+          new Class[]{streamFilterClass, String.class, boolean.class},
+          new Object[]{null, dictionaryDir, false});
+      tokenizer.setReader(reader);
+      tokenizer.reset();
       CharTermAttribute attr = (CharTermAttribute)tokenizer.getAttribute(CharTermAttribute.class);
       Attribute posAttr = (Attribute)tokenizer.getAttribute(container.loadComponent("org.apache.lucene.analysis.gosen.tokenAttributes.PartOfSpeechAttribute"));
       Attribute costAttr = (Attribute)tokenizer.getAttribute(container.loadComponent("org.apache.lucene.analysis.gosen.tokenAttributes.CostAttribute"));
       while (tokenizer.incrementToken()) {
-        //TODO getCost execute by reflaction  
+        //TODO getCost execute by reflaction
         result.addCost( Integer.valueOf(costAttr.getClass().getMethod("getCost").invoke(costAttr).toString())  );
         result.addTerm(attr.toString());
         result.addPos(posAttr.toString());
       }
+      tokenizer.close();
     }catch(ClassNotFoundException cnfe){
       System.err.println("ClassNotFound!!!");
       throw new RuntimeException(cnfe);
@@ -59,6 +86,7 @@ public class WikipediaModelAnalyzer {
       System.err.println("target:["+target+"]");
       ioe.printStackTrace();
     }
+    return false; // not skipped
   }
  
   

--- a/src/test/java/lucene/gosen/wikipedia/MavenJarDownloaderTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/MavenJarDownloaderTest.java
@@ -29,7 +29,7 @@ class MavenJarDownloaderTest {
 
         // Note: 実際のダウンロードは時間がかかるため、無効なバージョンでテスト
         try {
-            MavenJarDownloader.downloadLuceneGosenWithDependencies("0.0.0-invalid", destDir);
+            MavenJarDownloader.downloadLuceneGosenWithDependencies("0.0.0-invalid", destDir, "ipadic");
             fail("Should throw exception for invalid version");
         } catch (Exception e) {
             // 期待される動作: 例外が発生
@@ -44,7 +44,7 @@ class MavenJarDownloaderTest {
         String destDir = tempDir.resolve("test").toString();
 
         assertThrows(Exception.class, () -> {
-            MavenJarDownloader.downloadLuceneGosenWithDependencies(null, destDir);
+            MavenJarDownloader.downloadLuceneGosenWithDependencies(null, destDir, "ipadic");
         });
     }
 
@@ -53,14 +53,14 @@ class MavenJarDownloaderTest {
         String destDir = tempDir.resolve("test").toString();
 
         assertThrows(Exception.class, () -> {
-            MavenJarDownloader.downloadLuceneGosenWithDependencies("", destDir);
+            MavenJarDownloader.downloadLuceneGosenWithDependencies("", destDir, "ipadic");
         });
     }
 
     @Test
     void testDownloadLuceneGosenWithNullDestDir() {
         assertThrows(Exception.class, () -> {
-            MavenJarDownloader.downloadLuceneGosenWithDependencies("6.2.1", null);
+            MavenJarDownloader.downloadLuceneGosenWithDependencies("6.2.1", null, "ipadic");
         });
     }
 
@@ -72,7 +72,7 @@ class MavenJarDownloaderTest {
         assertFalse(Files.exists(Path.of(destDir)));
 
         try {
-            MavenJarDownloader.downloadLuceneGosenWithDependencies("0.0.0-invalid", destDir);
+            MavenJarDownloader.downloadLuceneGosenWithDependencies("0.0.0-invalid", destDir, "ipadic");
             fail("Should throw exception");
         } catch (Exception e) {
             // 複数レベルのディレクトリが作成されていることを確認
@@ -88,7 +88,7 @@ class MavenJarDownloaderTest {
 
         // 既存のディレクトリがある場合でもエラーにならないことを確認
         try {
-            MavenJarDownloader.downloadLuceneGosenWithDependencies("0.0.0-invalid", destDir.toString());
+            MavenJarDownloader.downloadLuceneGosenWithDependencies("0.0.0-invalid", destDir.toString(), "ipadic");
             fail("Should throw exception for invalid version");
         } catch (Exception e) {
             // ディレクトリは残っている
@@ -103,7 +103,7 @@ class MavenJarDownloaderTest {
 
         // 無効なバージョン形式
         assertThrows(Exception.class, () -> {
-            MavenJarDownloader.downloadLuceneGosenWithDependencies("invalid-version-format", destDir);
+            MavenJarDownloader.downloadLuceneGosenWithDependencies("invalid-version-format", destDir, "ipadic");
         });
     }
 


### PR DESCRIPTION
## Summary
- WikipediaModelAnalyzerにデフォルトコンストラクタを追加し、空文字のスキップ処理を実装
- Wiki40bParquetParser/PagesArticlesXmlParserに10件以下の場合の詳細出力機能を追加
- スキップ件数のカウントと出力を追加
- ComponentContainerのエラーメッセージに例外情報を追加
- MavenJarDownloaderTestにclassifierパラメータを追加
- build.gradleでUTF-8エンコーディング設定と依存関係のバージョンを更新

## Changes
### WikipediaModelAnalyzer
- デフォルトコンストラクタを追加（`dictionaryDir`をnullに設定）
- `analyze`メソッドでtitleとtextの両方が空の場合にスキップするロジックを実装
- `tokenizer.reset()`と`tokenizer.close()`を追加してTokenStreamの契約違反を修正

### Wiki40bParquetParser & PagesArticlesXmlParser
- 処理件数が10件以下の場合に詳細結果（タイトル、テキスト、OLD/NEW解析結果）をコンソールに出力
- スキップ件数をカウントし、最終結果に表示
- `compareResult`メソッドに`printToConsole`パラメータを追加

### その他
- ComponentContainerのエラーメッセージに例外のスタックトレースを含めるよう改善
- MavenJarDownloaderTestの全テストケースに`classifier`パラメータ（`"ipadic"`）を追加
- build.gradleの全JavaExecタスクに`systemProperty 'file.encoding', 'UTF-8'`を追加
- 依存関係のバージョンを更新（Parquet 1.17.0, Hadoop 3.4.2など）

## Test plan
- [ ] テストビルドが成功することを確認
- [ ] `runParser`タスクで10件以下の処理時に詳細出力が表示されることを確認
- [ ] `runWiki40bParser`タスクで10件以下の処理時に詳細出力が表示されることを確認
- [ ] スキップ件数が正しくカウントされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)