### PR TITLE
HTMLレポート機能の実装 (#2対応)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,18 @@ classifierを指定することも可能です（デフォルト: ipadic）：
 - `arg[1]`: 新バージョンの JAR ファイルパスまたはディレクトリパス
 - `arg[2]` (オプション): Wikipedia XMLファイルのパス（デフォルト: `./data/jawiki-latest-pages-articles.xml`）
 - `arg[3]` (オプション): 処理する最大件数（デフォルト: 全件処理）
+- `arg[4]` (オプション): レポート形式 (`text`|`html`|`both`、デフォルト: `both`)
 
 **処理件数を制限した軽量テスト：**
 ```powershell
-# 100件だけ処理
+# 100件だけ処理（HTMLとテキストの両方を生成）
 .\gradlew runParser --args="lib/6.0.1 lib/6.2.1 data/jawiki-latest-pages-articles.xml 100"
+
+# HTMLレポートのみ生成
+.\gradlew runParser --args="lib/6.0.1 lib/6.2.1 data/jawiki-latest-pages-articles.xml 100 html"
+
+# テキストレポートのみ生成
+.\gradlew runParser --args="lib/6.0.1 lib/6.2.1 data/jawiki-latest-pages-articles.xml 100 text"
 ```
 
 #### 方法2: Wiki-40B Parquetファイルを使用
@@ -164,14 +171,41 @@ Wiki-40Bデータセットを使用する場合は、専用のパーサーを使
 
 ## 出力結果
 
-実行が完了すると、差分がある場合に以下のファイルに詳細が出力されます：
-- Wikipedia XMLパーサー: `diff_result.txt`
-- Wiki-40B Parquetパーサー: `diff_result_wiki40b.txt`
+実行が完了すると、以下のレポートファイルが生成されます：
 
-**出力内容：**
+### Wikipedia XMLパーサー
+- **HTMLレポート**: `diff_result.html` - 視覚的で詳細なレポート（推奨）
+- **テキストレポート**: `diff_result.txt` - 従来のテキスト形式
+
+### Wiki-40B Parquetパーサー
+- `diff_result_wiki40b.txt`
+
+### HTMLレポートの内容
+
+**実行情報セクション**
+- 実行開始/終了時刻、実行時間
+- Old/New JARパスとファイル一覧
+- Wikipedia XMLファイルパス
+- 最大レコード数設定
+
+**サマリーセクション**
+- 総処理数、差分あり件数、一致件数、スキップ件数
+- 差分率と一致率（パーセンテージ表示）
+- カラフルなカード形式で視覚的に表示
+
+**差分詳細セクション**
+- 差分がある記事のテーブル表示
+- 差分タイプ（cost/term/pos）のバッジ表示
+- クリックで詳細を表示/非表示
+- Old/Newの横並び比較表示
+- 元のWikipediaテキストも表示可能
+
+### テキストレポートの内容
+- 実行情報ヘッダー
 - `analyze result[cost] is different!!`: コストの合計値が異なる場合
 - `analyze result[termList] is different!!`: 抽出された単語リストが異なる場合
 - `analyze result[posList] is different!!`: 品詞リストが異なる場合
+- 処理結果サマリー
 
 ## プロジェクト構造
 

--- a/src/main/java/lucene/gosen/wikipedia/PagesArticlesXmlParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/PagesArticlesXmlParser.java
@@ -15,14 +15,15 @@
  */
 package lucene.gosen.wikipedia;
 
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
@@ -35,6 +36,10 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import lucene.gosen.test.util.AnalyzeResult;
 import lucene.gosen.test.util.ComponentContainer;
 import lucene.gosen.wikipedia.analyzer.WikipediaModelAnalyzer;
+import lucene.gosen.wikipedia.report.ExecutionInfo;
+import lucene.gosen.wikipedia.report.HtmlReportGenerator;
+import lucene.gosen.wikipedia.report.ReportGenerator;
+import lucene.gosen.wikipedia.report.TextReportGenerator;
 
 /**
  * Wikipediaのjawiki-latest-pages-articles.xmlを解析する
@@ -51,7 +56,7 @@ public class PagesArticlesXmlParser {
 
     long start = System.currentTimeMillis();
     if (args.length < 2) {
-      System.out.println("arg[0] is old jar or directory, arg[1] is new jar or directory, [arg[2] is wikipedia xml file (default: ./data/jawiki-latest-pages-articles.xml)], [arg[3] is max record count (optional, default: all records)]");
+      System.out.println("arg[0] is old jar or directory, arg[1] is new jar or directory, [arg[2] is wikipedia xml file (default: ./data/jawiki-latest-pages-articles.xml)], [arg[3] is max record count (optional, default: all records)], [arg[4] is report format (text|html|both, default: both)]");
       System.exit(-1);
     }
 
@@ -72,23 +77,56 @@ public class PagesArticlesXmlParser {
       }
     }
 
-    BufferedWriter bw = new BufferedWriter(new FileWriter("diff_result.txt"));
+    // Parse report format
+    String reportFormat = args.length >= 5 ? args[4].toLowerCase() : "both";
+    if (!reportFormat.equals("text") && !reportFormat.equals("html") && !reportFormat.equals("both")) {
+      System.err.println("Error: report format must be 'text', 'html', or 'both', got: " + reportFormat);
+      System.exit(-1);
+    }
+
+    // 実行情報を収集
+    ExecutionInfo execInfo = new ExecutionInfo();
+    execInfo.setOldJarPath(args[0]);
+    execInfo.setNewJarPath(args[1]);
+    execInfo.setXmlPath(xmlPath);
+    execInfo.setMaxRecordCount(maxRecordCount);
+    execInfo.setReportFormat(reportFormat);
+    execInfo.setStartTime(new Date(start));
+
+    // JAR ファイル情報を収集
+    File[] oldJarFiles = getJarFiles(args[0]);
+    File[] newJarFiles = getJarFiles(args[1]);
+    execInfo.setOldJarFiles(Arrays.stream(oldJarFiles).map(File::getName).toList());
+    execInfo.setNewJarFiles(Arrays.stream(newJarFiles).map(File::getName).toList());
+
+    // レポートジェネレーターを初期化
+    List<ReportGenerator> reportGenerators = new ArrayList<>();
+    if (reportFormat.equals("text") || reportFormat.equals("both")) {
+      TextReportGenerator textGen = new TextReportGenerator("diff_result.txt");
+      textGen.setExecutionInfo(execInfo);
+      reportGenerators.add(textGen);
+    }
+    if (reportFormat.equals("html") || reportFormat.equals("both")) {
+      HtmlReportGenerator htmlGen = new HtmlReportGenerator();
+      htmlGen.setExecutionInfo(execInfo);
+      reportGenerators.add(htmlGen);
+    }
 
     System.out.println("start :: "+sdf.format(new Date(start)));
-    ComponentContainer oldJarContainer = new ComponentContainer(getJarFiles(args[0]));
-    ComponentContainer newJarContainer = new ComponentContainer(getJarFiles(args[1]));
+    ComponentContainer oldJarContainer = new ComponentContainer(oldJarFiles);
+    ComponentContainer newJarContainer = new ComponentContainer(newJarFiles);
 
     WikipediaModelAnalyzer oldModelAnalyzer = (WikipediaModelAnalyzer)oldJarContainer.createComponent("lucene.gosen.wikipedia.analyzer.WikipediaModelAnalyzer", null, null);
     WikipediaModelAnalyzer newModelAnalyzer = (WikipediaModelAnalyzer)newJarContainer.createComponent("lucene.gosen.wikipedia.analyzer.WikipediaModelAnalyzer", null, null);
-    
-    
+
+
     AnalyzeResult[] oldResult = new AnalyzeResult[RESULT_SIZE];
     AnalyzeResult[] newResult = new AnalyzeResult[RESULT_SIZE];
     for(int i=0;i<RESULT_SIZE;i++){
       oldResult[i] = new AnalyzeResult();
       newResult[i] = new AnalyzeResult();
     }
-    
+
     XMLInputFactory factory = XMLInputFactory.newInstance();
     try (InputStream is = getInputStream(xmlPath)) {
       XMLEventReader reader = factory.createXMLEventReader(is);
@@ -105,8 +143,14 @@ public class PagesArticlesXmlParser {
             int skipped = oldModelAnalyzer.analyze(model, oldJarContainer, oldResult);
             newModelAnalyzer.analyze(model, newJarContainer, newResult);
             skippedCounter += skipped;
-            if(compareResult(bw, model, oldResult, newResult, printToConsole)){
-              falseCounter++;;
+            boolean hasDifference = compareResult(model, oldResult, newResult);
+            if(hasDifference){
+              falseCounter++;
+            }
+
+            // 各レポートジェネレーターに結果を追加
+            for (ReportGenerator generator : reportGenerators) {
+              generator.addDiffResult(model, oldResult, newResult, hasDifference, printToConsole);
             }
 
             if (printToConsole) {
@@ -115,7 +159,9 @@ public class PagesArticlesXmlParser {
 
             if(counter % 1000 == 0){
               System.out.println("success count:"+counter);
-              bw.flush();
+              for (ReportGenerator generator : reportGenerators) {
+                generator.flush();
+              }
             }
             counter++;
 
@@ -129,7 +175,26 @@ public class PagesArticlesXmlParser {
       }
 
       reader.close();
-      bw.close();
+
+      // 実行情報の最終更新
+      execInfo.setEndTime(new Date());
+      execInfo.setDurationMs(System.currentTimeMillis() - start);
+      execInfo.setTotalProcessed(counter);
+      execInfo.setDifferenceCount(falseCounter);
+      execInfo.setSkippedCount(skippedCounter);
+
+      // レポート生成
+      for (ReportGenerator generator : reportGenerators) {
+        if (generator instanceof TextReportGenerator) {
+          generator.generateReport("diff_result.txt");
+          System.out.println("Text report generated: diff_result.txt");
+        } else if (generator instanceof HtmlReportGenerator) {
+          generator.generateReport("diff_result.html");
+          System.out.println("HTML report generated: diff_result.html");
+        }
+        generator.close();
+      }
+
       System.out.println("total processed: " + counter);
       System.out.println("falseCounter: " + falseCounter);
       System.out.println("skippedCounter: " + skippedCounter);
@@ -147,73 +212,18 @@ public class PagesArticlesXmlParser {
     return is;
   }
   
-  private static boolean compareResult(BufferedWriter bw, WikipediaModel model, AnalyzeResult[] oldResult, AnalyzeResult[] newResult, boolean printToConsole)throws IOException{
-
+  private static boolean compareResult(WikipediaModel model, AnalyzeResult[] oldResult, AnalyzeResult[] newResult) {
     boolean different = false;
 
     //size check
     for(int i=0;i<RESULT_SIZE;i++){
       if(oldResult[i].getTotalCost() != newResult[i].getTotalCost()){
-        String msg = "analyze result[cost] is different!!";
-        bw.append(msg);
-        bw.newLine();
-        if (printToConsole) System.out.println(msg);
-
-        String oldMsg = "  old["+oldResult[i].getTotalCost()+"]";
-        bw.append(oldMsg);
-        bw.newLine();
-        if (printToConsole) System.out.println(oldMsg);
-
-        String newMsg = "  new["+newResult[i].getTotalCost()+"]";
-        bw.append(newMsg);
-        bw.newLine();
-        if (printToConsole) System.out.println(newMsg);
-
         different = true;
       }
-      if(different){
-        if(i==0){
-          bw.append(model.title);
-          if (printToConsole) System.out.println("Title: " + model.title);
-        }else{
-          //System.out.println(model.text);
-        }
-        //System.exit(-1);
-      }
       if(!oldResult[i].getTermList().equals(newResult[i].getTermList())){
-        String msg = "analyze result[termList] is different!!";
-        bw.append(msg);
-        bw.newLine();
-        if (printToConsole) System.out.println(msg);
-
-        String oldMsg = "  old["+oldResult[i].getTermList().toString()+"]";
-        bw.append(oldMsg);
-        bw.newLine();
-        if (printToConsole) System.out.println(oldMsg);
-
-        String newMsg = "  new["+newResult[i].getTermList().toString()+"]";
-        bw.append(newMsg);
-        bw.newLine();
-        if (printToConsole) System.out.println(newMsg);
-
         different = true;
       }
       if(!oldResult[i].getPosList().equals(newResult[i].getPosList())){
-        String msg = "analyze result[posList] is different!!";
-        bw.append(msg);
-        bw.newLine();
-        if (printToConsole) System.out.println(msg);
-
-        String oldMsg = "  old["+oldResult[i].getPosList().toString()+"]";
-        bw.append(oldMsg);
-        bw.newLine();
-        if (printToConsole) System.out.println(oldMsg);
-
-        String newMsg = "  new["+newResult[i].getPosList().toString()+"]";
-        bw.append(newMsg);
-        bw.newLine();
-        if (printToConsole) System.out.println(newMsg);
-
         different = true;
       }
       break;

--- a/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2012 Jun Ohtani
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lucene.gosen.wikipedia.report;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * レポート生成のための実行情報を保持するクラス
+ */
+public class ExecutionInfo {
+    private String oldJarPath;
+    private String newJarPath;
+    private String xmlPath;
+    private int maxRecordCount;
+    private String reportFormat;
+    private String outputDirectory;
+    private Date startTime;
+    private Date endTime;
+    private long durationMs;
+    private List<String> oldJarFiles;
+    private List<String> newJarFiles;
+
+    // 処理結果のサマリー
+    private int totalProcessed;
+    private int differenceCount;
+    private int skippedCount;
+
+    public String getOldJarPath() {
+        return oldJarPath;
+    }
+
+    public void setOldJarPath(String oldJarPath) {
+        this.oldJarPath = oldJarPath;
+    }
+
+    public String getNewJarPath() {
+        return newJarPath;
+    }
+
+    public void setNewJarPath(String newJarPath) {
+        this.newJarPath = newJarPath;
+    }
+
+    public String getXmlPath() {
+        return xmlPath;
+    }
+
+    public void setXmlPath(String xmlPath) {
+        this.xmlPath = xmlPath;
+    }
+
+    public int getMaxRecordCount() {
+        return maxRecordCount;
+    }
+
+    public void setMaxRecordCount(int maxRecordCount) {
+        this.maxRecordCount = maxRecordCount;
+    }
+
+    public String getReportFormat() {
+        return reportFormat;
+    }
+
+    public void setReportFormat(String reportFormat) {
+        this.reportFormat = reportFormat;
+    }
+
+    public String getOutputDirectory() {
+        return outputDirectory;
+    }
+
+    public void setOutputDirectory(String outputDirectory) {
+        this.outputDirectory = outputDirectory;
+    }
+
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Date startTime) {
+        this.startTime = startTime;
+    }
+
+    public Date getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Date endTime) {
+        this.endTime = endTime;
+    }
+
+    public long getDurationMs() {
+        return durationMs;
+    }
+
+    public void setDurationMs(long durationMs) {
+        this.durationMs = durationMs;
+    }
+
+    public List<String> getOldJarFiles() {
+        return oldJarFiles;
+    }
+
+    public void setOldJarFiles(List<String> oldJarFiles) {
+        this.oldJarFiles = oldJarFiles;
+    }
+
+    public List<String> getNewJarFiles() {
+        return newJarFiles;
+    }
+
+    public void setNewJarFiles(List<String> newJarFiles) {
+        this.newJarFiles = newJarFiles;
+    }
+
+    public int getTotalProcessed() {
+        return totalProcessed;
+    }
+
+    public void setTotalProcessed(int totalProcessed) {
+        this.totalProcessed = totalProcessed;
+    }
+
+    public int getDifferenceCount() {
+        return differenceCount;
+    }
+
+    public void setDifferenceCount(int differenceCount) {
+        this.differenceCount = differenceCount;
+    }
+
+    public int getSkippedCount() {
+        return skippedCount;
+    }
+
+    public void setSkippedCount(int skippedCount) {
+        this.skippedCount = skippedCount;
+    }
+}

--- a/src/main/java/lucene/gosen/wikipedia/report/HtmlReportGenerator.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/HtmlReportGenerator.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2012 Jun Ohtani
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lucene.gosen.wikipedia.report;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+
+import lucene.gosen.test.util.AnalyzeResult;
+import lucene.gosen.wikipedia.WikipediaModel;
+
+/**
+ * HTML形式のレポート生成クラス
+ */
+public class HtmlReportGenerator implements ReportGenerator {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final int RESULT_SIZE = 2;
+
+    private ExecutionInfo execInfo;
+    private List<DiffRecord> diffRecords = new ArrayList<>();
+
+    @Override
+    public void setExecutionInfo(ExecutionInfo info) {
+        this.execInfo = info;
+    }
+
+    @Override
+    public void addDiffResult(WikipediaModel model, AnalyzeResult[] oldResult,
+                             AnalyzeResult[] newResult, boolean hasDifference,
+                             boolean printToConsole) throws IOException {
+        if (!hasDifference) {
+            return; // 差分がない場合は記録しない
+        }
+
+        // 差分レコードを作成
+        DiffRecord record = new DiffRecord();
+        record.title = model.getTitle();
+        record.text = model.getText();
+        record.oldResult = copyResults(oldResult);
+        record.newResult = copyResults(newResult);
+        record.diffTypes = detectDiffTypes(oldResult, newResult);
+
+        diffRecords.add(record);
+    }
+
+    private AnalyzeResult[] copyResults(AnalyzeResult[] source) {
+        AnalyzeResult[] copy = new AnalyzeResult[source.length];
+        for (int i = 0; i < source.length; i++) {
+            copy[i] = new AnalyzeResult();
+            copy[i].getTermList().addAll(source[i].getTermList());
+            copy[i].getPosList().addAll(source[i].getPosList());
+            copy[i].addCost(source[i].getTotalCost());
+        }
+        return copy;
+    }
+
+    private List<String> detectDiffTypes(AnalyzeResult[] oldResult, AnalyzeResult[] newResult) {
+        List<String> types = new ArrayList<>();
+        for (int i = 0; i < RESULT_SIZE; i++) {
+            if (oldResult[i].getTotalCost() != newResult[i].getTotalCost()) {
+                types.add("cost");
+            }
+            if (!oldResult[i].getTermList().equals(newResult[i].getTermList())) {
+                if (!types.contains("term")) types.add("term");
+            }
+            if (!oldResult[i].getPosList().equals(newResult[i].getPosList())) {
+                if (!types.contains("pos")) types.add("pos");
+            }
+            break;
+        }
+        return types;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        // HTMLは最後にまとめて出力するため、ここでは何もしない
+    }
+
+    @Override
+    public void generateReport(String outputPath) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputPath))) {
+            writeHtmlHeader(writer);
+            writeExecutionInfo(writer);
+            writeSummary(writer);
+            writeDiffDetails(writer);
+            writeHtmlFooter(writer);
+        }
+    }
+
+    private void writeHtmlHeader(BufferedWriter writer) throws IOException {
+        writer.write("<!DOCTYPE html>\n");
+        writer.write("<html lang=\"ja\">\n");
+        writer.write("<head>\n");
+        writer.write("  <meta charset=\"UTF-8\">\n");
+        writer.write("  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n");
+        writer.write("  <title>Wikipedia解析 差分レポート</title>\n");
+        writer.write("  <style>\n");
+        writeStyles(writer);
+        writer.write("  </style>\n");
+        writer.write("</head>\n");
+        writer.write("<body>\n");
+        writer.write("  <div class=\"container\">\n");
+        writer.write("    <h1>Wikipedia解析 差分レポート</h1>\n");
+    }
+
+    private void writeStyles(BufferedWriter writer) throws IOException {
+        writer.write("    body { font-family: 'Segoe UI', Arial, sans-serif; margin: 0; padding: 20px; background-color: #f5f5f5; }\n");
+        writer.write("    .container { max-width: 1400px; margin: 0 auto; background: white; padding: 30px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }\n");
+        writer.write("    h1 { color: #333; border-bottom: 3px solid #4CAF50; padding-bottom: 10px; }\n");
+        writer.write("    h2 { color: #555; margin-top: 30px; border-bottom: 2px solid #ddd; padding-bottom: 8px; }\n");
+        writer.write("    .info-section { background: #f9f9f9; padding: 20px; margin: 20px 0; border-radius: 5px; border-left: 4px solid #4CAF50; }\n");
+        writer.write("    .info-table { width: 100%; border-collapse: collapse; margin-top: 10px; }\n");
+        writer.write("    .info-table th { text-align: left; padding: 8px; background: #e8e8e8; width: 200px; }\n");
+        writer.write("    .info-table td { padding: 8px; border-bottom: 1px solid #ddd; }\n");
+        writer.write("    .jar-list { margin: 10px 0; padding-left: 20px; }\n");
+        writer.write("    .jar-list li { padding: 3px 0; color: #666; }\n");
+        writer.write("    .summary-section { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; margin: 20px 0; }\n");
+        writer.write("    .summary-card { background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 20px; border-radius: 8px; text-align: center; }\n");
+        writer.write("    .summary-card.success { background: linear-gradient(135deg, #4CAF50 0%, #45a049 100%); }\n");
+        writer.write("    .summary-card.warning { background: linear-gradient(135deg, #ff9800 0%, #f57c00 100%); }\n");
+        writer.write("    .summary-card.info { background: linear-gradient(135deg, #2196F3 0%, #1976D2 100%); }\n");
+        writer.write("    .summary-card .number { font-size: 36px; font-weight: bold; margin: 10px 0; }\n");
+        writer.write("    .summary-card .label { font-size: 14px; opacity: 0.9; }\n");
+        writer.write("    .diff-table { width: 100%; border-collapse: collapse; margin-top: 20px; }\n");
+        writer.write("    .diff-table th { background: #4CAF50; color: white; padding: 12px; text-align: left; position: sticky; top: 0; }\n");
+        writer.write("    .diff-table td { padding: 10px; border-bottom: 1px solid #ddd; }\n");
+        writer.write("    .diff-table tr:hover { background: #f5f5f5; }\n");
+        writer.write("    .diff-type { display: inline-block; padding: 3px 8px; margin: 2px; border-radius: 3px; font-size: 11px; font-weight: bold; }\n");
+        writer.write("    .diff-type.cost { background: #ffeb3b; color: #333; }\n");
+        writer.write("    .diff-type.term { background: #ff9800; color: white; }\n");
+        writer.write("    .diff-type.pos { background: #f44336; color: white; }\n");
+        writer.write("    .detail-row { background: #fafafa; display: none; }\n");
+        writer.write("    .detail-row td { padding: 20px; }\n");
+        writer.write("    .comparison { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }\n");
+        writer.write("    .comparison-panel { border: 1px solid #ddd; border-radius: 5px; padding: 15px; }\n");
+        writer.write("    .comparison-panel h4 { margin-top: 0; padding: 8px; border-radius: 3px; }\n");
+        writer.write("    .old-panel h4 { background: #ffebee; color: #c62828; }\n");
+        writer.write("    .new-panel h4 { background: #e8f5e9; color: #2e7d32; }\n");
+        writer.write("    .result-item { margin: 10px 0; padding: 10px; background: white; border-radius: 3px; }\n");
+        writer.write("    .result-label { font-weight: bold; color: #666; margin-bottom: 5px; }\n");
+        writer.write("    .result-value { font-family: 'Courier New', monospace; font-size: 13px; word-break: break-all; }\n");
+        writer.write("    .toggle-detail { cursor: pointer; color: #2196F3; text-decoration: underline; }\n");
+        writer.write("    .toggle-detail:hover { color: #1976D2; }\n");
+        writer.write("    details { margin: 10px 0; }\n");
+        writer.write("    summary { cursor: pointer; font-weight: bold; padding: 8px; background: #f0f0f0; border-radius: 3px; }\n");
+        writer.write("    summary:hover { background: #e0e0e0; }\n");
+    }
+
+    private void writeExecutionInfo(BufferedWriter writer) throws IOException {
+        writer.write("    <div class=\"info-section\">\n");
+        writer.write("      <h2>実行情報</h2>\n");
+        writer.write("      <table class=\"info-table\">\n");
+
+        if (execInfo.getStartTime() != null) {
+            writer.write("        <tr><th>実行開始時刻</th><td>" + escapeHtml(DATE_FORMAT.format(execInfo.getStartTime())) + "</td></tr>\n");
+        }
+        if (execInfo.getEndTime() != null) {
+            writer.write("        <tr><th>実行終了時刻</th><td>" + escapeHtml(DATE_FORMAT.format(execInfo.getEndTime())) + "</td></tr>\n");
+        }
+        if (execInfo.getDurationMs() > 0) {
+            writer.write("        <tr><th>実行時間</th><td>" + formatDuration(execInfo.getDurationMs()) + "</td></tr>\n");
+        }
+
+        writer.write("        <tr><th>Old JAR/Dir</th><td>" + escapeHtml(execInfo.getOldJarPath()) + "</td></tr>\n");
+        if (execInfo.getOldJarFiles() != null && !execInfo.getOldJarFiles().isEmpty()) {
+            writer.write("        <tr><td colspan=\"2\">");
+            writer.write("<details><summary>Old JAR files (" + execInfo.getOldJarFiles().size() + " files)</summary>");
+            writer.write("<ul class=\"jar-list\">");
+            for (String jar : execInfo.getOldJarFiles()) {
+                writer.write("<li>" + escapeHtml(jar) + "</li>");
+            }
+            writer.write("</ul></details>");
+            writer.write("</td></tr>\n");
+        }
+
+        writer.write("        <tr><th>New JAR/Dir</th><td>" + escapeHtml(execInfo.getNewJarPath()) + "</td></tr>\n");
+        if (execInfo.getNewJarFiles() != null && !execInfo.getNewJarFiles().isEmpty()) {
+            writer.write("        <tr><td colspan=\"2\">");
+            writer.write("<details><summary>New JAR files (" + execInfo.getNewJarFiles().size() + " files)</summary>");
+            writer.write("<ul class=\"jar-list\">");
+            for (String jar : execInfo.getNewJarFiles()) {
+                writer.write("<li>" + escapeHtml(jar) + "</li>");
+            }
+            writer.write("</ul></details>");
+            writer.write("</td></tr>\n");
+        }
+
+        writer.write("        <tr><th>Wikipedia XML</th><td>" + escapeHtml(execInfo.getXmlPath()) + "</td></tr>\n");
+
+        String recordLimit = execInfo.getMaxRecordCount() > 0
+                ? execInfo.getMaxRecordCount() + " (制限あり)"
+                : "全件処理";
+        writer.write("        <tr><th>最大レコード数</th><td>" + escapeHtml(recordLimit) + "</td></tr>\n");
+
+        writer.write("      </table>\n");
+        writer.write("    </div>\n");
+    }
+
+    private void writeSummary(BufferedWriter writer) throws IOException {
+        writer.write("    <h2>処理結果サマリー</h2>\n");
+        writer.write("    <div class=\"summary-section\">\n");
+
+        writer.write("      <div class=\"summary-card info\">\n");
+        writer.write("        <div class=\"label\">総処理数</div>\n");
+        writer.write("        <div class=\"number\">" + execInfo.getTotalProcessed() + "</div>\n");
+        writer.write("      </div>\n");
+
+        writer.write("      <div class=\"summary-card warning\">\n");
+        writer.write("        <div class=\"label\">差分あり</div>\n");
+        writer.write("        <div class=\"number\">" + execInfo.getDifferenceCount() + "</div>\n");
+        double diffRate = execInfo.getTotalProcessed() > 0
+                ? (double) execInfo.getDifferenceCount() / execInfo.getTotalProcessed() * 100
+                : 0;
+        writer.write("        <div class=\"label\">" + String.format("%.2f%%", diffRate) + "</div>\n");
+        writer.write("      </div>\n");
+
+        writer.write("      <div class=\"summary-card success\">\n");
+        writer.write("        <div class=\"label\">一致</div>\n");
+        int matchCount = execInfo.getTotalProcessed() - execInfo.getDifferenceCount();
+        writer.write("        <div class=\"number\">" + matchCount + "</div>\n");
+        double matchRate = execInfo.getTotalProcessed() > 0
+                ? (double) matchCount / execInfo.getTotalProcessed() * 100
+                : 0;
+        writer.write("        <div class=\"label\">" + String.format("%.2f%%", matchRate) + "</div>\n");
+        writer.write("      </div>\n");
+
+        writer.write("      <div class=\"summary-card info\">\n");
+        writer.write("        <div class=\"label\">スキップ</div>\n");
+        writer.write("        <div class=\"number\">" + execInfo.getSkippedCount() + "</div>\n");
+        writer.write("      </div>\n");
+
+        writer.write("    </div>\n");
+    }
+
+    private void writeDiffDetails(BufferedWriter writer) throws IOException {
+        writer.write("    <h2>差分詳細 (" + diffRecords.size() + "件)</h2>\n");
+
+        if (diffRecords.isEmpty()) {
+            writer.write("    <p>差分はありません。</p>\n");
+            return;
+        }
+
+        writer.write("    <table class=\"diff-table\">\n");
+        writer.write("      <thead>\n");
+        writer.write("        <tr>\n");
+        writer.write("          <th style=\"width: 50px;\">#</th>\n");
+        writer.write("          <th>タイトル</th>\n");
+        writer.write("          <th style=\"width: 200px;\">差分タイプ</th>\n");
+        writer.write("          <th style=\"width: 100px;\">詳細</th>\n");
+        writer.write("        </tr>\n");
+        writer.write("      </thead>\n");
+        writer.write("      <tbody>\n");
+
+        int index = 1;
+        for (DiffRecord record : diffRecords) {
+            String rowId = "row-" + index;
+            String detailId = "detail-" + index;
+
+            writer.write("        <tr id=\"" + rowId + "\">\n");
+            writer.write("          <td>" + index + "</td>\n");
+            writer.write("          <td>" + escapeHtml(record.title) + "</td>\n");
+            writer.write("          <td>");
+            for (String type : record.diffTypes) {
+                writer.write("<span class=\"diff-type " + type + "\">" + type.toUpperCase() + "</span> ");
+            }
+            writer.write("</td>\n");
+            writer.write("          <td><span class=\"toggle-detail\" onclick=\"toggleDetail('" + detailId + "')\">表示/非表示</span></td>\n");
+            writer.write("        </tr>\n");
+
+            writer.write("        <tr id=\"" + detailId + "\" class=\"detail-row\">\n");
+            writer.write("          <td colspan=\"4\">\n");
+            writeDiffDetail(writer, record);
+            writer.write("          </td>\n");
+            writer.write("        </tr>\n");
+
+            index++;
+        }
+
+        writer.write("      </tbody>\n");
+        writer.write("    </table>\n");
+    }
+
+    private void writeDiffDetail(BufferedWriter writer, DiffRecord record) throws IOException {
+        writer.write("            <div class=\"comparison\">\n");
+
+        // Old panel
+        writer.write("              <div class=\"comparison-panel old-panel\">\n");
+        writer.write("                <h4>OLD</h4>\n");
+        writeAnalyzeResults(writer, record.oldResult);
+        writer.write("              </div>\n");
+
+        // New panel
+        writer.write("              <div class=\"comparison-panel new-panel\">\n");
+        writer.write("                <h4>NEW</h4>\n");
+        writeAnalyzeResults(writer, record.newResult);
+        writer.write("              </div>\n");
+
+        writer.write("            </div>\n");
+
+        // 元テキスト
+        if (record.text != null && !record.text.isEmpty()) {
+            writer.write("            <details style=\"margin-top: 15px;\">\n");
+            writer.write("              <summary>元テキスト</summary>\n");
+            writer.write("              <div style=\"padding: 10px; background: #f9f9f9; margin-top: 10px; white-space: pre-wrap; font-size: 13px;\">");
+            writer.write(escapeHtml(record.text.substring(0, Math.min(500, record.text.length()))));
+            if (record.text.length() > 500) {
+                writer.write("...(省略)");
+            }
+            writer.write("</div>\n");
+            writer.write("            </details>\n");
+        }
+    }
+
+    private void writeAnalyzeResults(BufferedWriter writer, AnalyzeResult[] results) throws IOException {
+        for (int i = 0; i < Math.min(results.length, 1); i++) {
+            AnalyzeResult result = results[i];
+
+            writer.write("                <div class=\"result-item\">\n");
+            writer.write("                  <div class=\"result-label\">Terms:</div>\n");
+            writer.write("                  <div class=\"result-value\">" + escapeHtml(result.getTermList().toString()) + "</div>\n");
+            writer.write("                </div>\n");
+
+            writer.write("                <div class=\"result-item\">\n");
+            writer.write("                  <div class=\"result-label\">POS:</div>\n");
+            writer.write("                  <div class=\"result-value\">" + escapeHtml(result.getPosList().toString()) + "</div>\n");
+            writer.write("                </div>\n");
+
+            writer.write("                <div class=\"result-item\">\n");
+            writer.write("                  <div class=\"result-label\">Total Cost:</div>\n");
+            writer.write("                  <div class=\"result-value\">" + result.getTotalCost() + "</div>\n");
+            writer.write("                </div>\n");
+        }
+    }
+
+    private void writeHtmlFooter(BufferedWriter writer) throws IOException {
+        writer.write("    <script>\n");
+        writer.write("      function toggleDetail(id) {\n");
+        writer.write("        var element = document.getElementById(id);\n");
+        writer.write("        if (element.style.display === 'table-row') {\n");
+        writer.write("          element.style.display = 'none';\n");
+        writer.write("        } else {\n");
+        writer.write("          element.style.display = 'table-row';\n");
+        writer.write("        }\n");
+        writer.write("      }\n");
+        writer.write("    </script>\n");
+        writer.write("  </div>\n");
+        writer.write("</body>\n");
+        writer.write("</html>\n");
+    }
+
+    private String escapeHtml(String text) {
+        if (text == null) return "";
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private String formatDuration(long ms) {
+        long seconds = ms / 1000;
+        long minutes = seconds / 60;
+        long hours = minutes / 60;
+
+        if (hours > 0) {
+            return String.format("%d時間%d分%d秒 (%d ms)", hours, minutes % 60, seconds % 60, ms);
+        } else if (minutes > 0) {
+            return String.format("%d分%d秒 (%d ms)", minutes, seconds % 60, ms);
+        } else {
+            return String.format("%d秒 (%d ms)", seconds, ms);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        // リソースのクリーンアップ（必要に応じて）
+    }
+
+    /**
+     * 差分レコードを保持する内部クラス
+     */
+    private static class DiffRecord {
+        String title;
+        String text;
+        AnalyzeResult[] oldResult;
+        AnalyzeResult[] newResult;
+        List<String> diffTypes;
+    }
+}

--- a/src/main/java/lucene/gosen/wikipedia/report/ReportGenerator.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/ReportGenerator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012 Jun Ohtani
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lucene.gosen.wikipedia.report;
+
+import java.io.IOException;
+
+import lucene.gosen.test.util.AnalyzeResult;
+import lucene.gosen.wikipedia.WikipediaModel;
+
+/**
+ * レポート生成のインターフェース
+ */
+public interface ReportGenerator {
+
+    /**
+     * 実行情報を設定
+     * @param info 実行情報
+     */
+    void setExecutionInfo(ExecutionInfo info);
+
+    /**
+     * 差分結果を追加
+     * @param model Wikipediaモデル
+     * @param oldResult 旧バージョンの解析結果
+     * @param newResult 新バージョンの解析結果
+     * @param hasDifference 差分があるかどうか
+     * @param printToConsole コンソールに出力するかどうか
+     * @throws IOException IO例外
+     */
+    void addDiffResult(WikipediaModel model, AnalyzeResult[] oldResult,
+                      AnalyzeResult[] newResult, boolean hasDifference,
+                      boolean printToConsole) throws IOException;
+
+    /**
+     * レポートを生成
+     * @param outputPath 出力パス
+     * @throws IOException IO例外
+     */
+    void generateReport(String outputPath) throws IOException;
+
+    /**
+     * 定期的なフラッシュ（大量データ処理時のメモリ対策）
+     * @throws IOException IO例外
+     */
+    void flush() throws IOException;
+
+    /**
+     * リソースのクローズ
+     * @throws IOException IO例外
+     */
+    void close() throws IOException;
+}

--- a/src/main/java/lucene/gosen/wikipedia/report/TextReportGenerator.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/TextReportGenerator.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2012 Jun Ohtani
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package lucene.gosen.wikipedia.report;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+
+import lucene.gosen.test.util.AnalyzeResult;
+import lucene.gosen.wikipedia.WikipediaModel;
+
+/**
+ * テキスト形式のレポート生成クラス
+ */
+public class TextReportGenerator implements ReportGenerator {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final int RESULT_SIZE = 2;
+
+    private BufferedWriter writer;
+    private ExecutionInfo execInfo;
+    private boolean headerWritten = false;
+
+    public TextReportGenerator(String outputPath) throws IOException {
+        this.writer = new BufferedWriter(new FileWriter(outputPath));
+    }
+
+    @Override
+    public void setExecutionInfo(ExecutionInfo info) {
+        this.execInfo = info;
+    }
+
+    @Override
+    public void addDiffResult(WikipediaModel model, AnalyzeResult[] oldResult,
+                             AnalyzeResult[] newResult, boolean hasDifference,
+                             boolean printToConsole) throws IOException {
+        // ヘッダーをまだ書いていない場合は書く
+        if (!headerWritten && execInfo != null) {
+            writeHeader();
+            headerWritten = true;
+        }
+
+        if (!hasDifference) {
+            return; // 差分がない場合は何も書かない
+        }
+
+        // 既存のcompareResultロジックを使用
+        compareAndWriteResult(model, oldResult, newResult, printToConsole);
+    }
+
+    private void writeHeader() throws IOException {
+        writer.append("========================================");
+        writer.newLine();
+        writer.append("実行情報");
+        writer.newLine();
+        writer.append("========================================");
+        writer.newLine();
+
+        if (execInfo.getStartTime() != null) {
+            writer.append("実行開始時刻: ").append(DATE_FORMAT.format(execInfo.getStartTime()));
+            writer.newLine();
+        }
+
+        writer.append("Old JAR/Dir: ").append(execInfo.getOldJarPath());
+        writer.newLine();
+        if (execInfo.getOldJarFiles() != null && !execInfo.getOldJarFiles().isEmpty()) {
+            for (String jarFile : execInfo.getOldJarFiles()) {
+                writer.append("  - ").append(jarFile);
+                writer.newLine();
+            }
+        }
+
+        writer.append("New JAR/Dir: ").append(execInfo.getNewJarPath());
+        writer.newLine();
+        if (execInfo.getNewJarFiles() != null && !execInfo.getNewJarFiles().isEmpty()) {
+            for (String jarFile : execInfo.getNewJarFiles()) {
+                writer.append("  - ").append(jarFile);
+                writer.newLine();
+            }
+        }
+
+        writer.append("Wikipedia XML: ").append(execInfo.getXmlPath());
+        writer.newLine();
+
+        if (execInfo.getMaxRecordCount() > 0) {
+            writer.append("最大レコード数: ").append(String.valueOf(execInfo.getMaxRecordCount())).append(" (制限あり)");
+        } else {
+            writer.append("最大レコード数: 全件処理");
+        }
+        writer.newLine();
+
+        writer.newLine();
+        writer.append("========================================");
+        writer.newLine();
+        writer.append("差分詳細");
+        writer.newLine();
+        writer.append("========================================");
+        writer.newLine();
+        writer.newLine();
+    }
+
+    private void compareAndWriteResult(WikipediaModel model, AnalyzeResult[] oldResult,
+                                      AnalyzeResult[] newResult, boolean printToConsole) throws IOException {
+        boolean different = false;
+
+        // size check
+        for (int i = 0; i < RESULT_SIZE; i++) {
+            if (oldResult[i].getTotalCost() != newResult[i].getTotalCost()) {
+                String msg = "analyze result[cost] is different!!";
+                writer.append(msg);
+                writer.newLine();
+                if (printToConsole) System.out.println(msg);
+
+                String oldMsg = "  old[" + oldResult[i].getTotalCost() + "]";
+                writer.append(oldMsg);
+                writer.newLine();
+                if (printToConsole) System.out.println(oldMsg);
+
+                String newMsg = "  new[" + newResult[i].getTotalCost() + "]";
+                writer.append(newMsg);
+                writer.newLine();
+                if (printToConsole) System.out.println(newMsg);
+
+                different = true;
+            }
+            if (different) {
+                if (i == 0) {
+                    writer.append(model.getTitle());
+                    if (printToConsole) System.out.println("Title: " + model.getTitle());
+                } else {
+                    //System.out.println(model.getText());
+                }
+                //System.exit(-1);
+            }
+            if (!oldResult[i].getTermList().equals(newResult[i].getTermList())) {
+                String msg = "analyze result[termList] is different!!";
+                writer.append(msg);
+                writer.newLine();
+                if (printToConsole) System.out.println(msg);
+
+                String oldMsg = "  old[" + oldResult[i].getTermList().toString() + "]";
+                writer.append(oldMsg);
+                writer.newLine();
+                if (printToConsole) System.out.println(oldMsg);
+
+                String newMsg = "  new[" + newResult[i].getTermList().toString() + "]";
+                writer.append(newMsg);
+                writer.newLine();
+                if (printToConsole) System.out.println(newMsg);
+
+                different = true;
+            }
+            if (!oldResult[i].getPosList().equals(newResult[i].getPosList())) {
+                String msg = "analyze result[posList] is different!!";
+                writer.append(msg);
+                writer.newLine();
+                if (printToConsole) System.out.println(msg);
+
+                String oldMsg = "  old[" + oldResult[i].getPosList().toString() + "]";
+                writer.append(oldMsg);
+                writer.newLine();
+                if (printToConsole) System.out.println(oldMsg);
+
+                String newMsg = "  new[" + newResult[i].getPosList().toString() + "]";
+                writer.append(newMsg);
+                writer.newLine();
+                if (printToConsole) System.out.println(newMsg);
+
+                different = true;
+            }
+            break;
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (writer != null) {
+            writer.flush();
+        }
+    }
+
+    @Override
+    public void generateReport(String outputPath) throws IOException {
+        // 最後にサマリーを追記
+        if (execInfo != null) {
+            writer.newLine();
+            writer.append("========================================");
+            writer.newLine();
+            writer.append("処理結果サマリー");
+            writer.newLine();
+            writer.append("========================================");
+            writer.newLine();
+
+            if (execInfo.getEndTime() != null) {
+                writer.append("実行終了時刻: ").append(DATE_FORMAT.format(execInfo.getEndTime()));
+                writer.newLine();
+            }
+
+            if (execInfo.getDurationMs() > 0) {
+                writer.append("実行時間: ").append(String.valueOf(execInfo.getDurationMs())).append(" msec");
+                writer.newLine();
+            }
+
+            writer.append("total processed: ").append(String.valueOf(execInfo.getTotalProcessed()));
+            writer.newLine();
+            writer.append("falseCounter: ").append(String.valueOf(execInfo.getDifferenceCount()));
+            writer.newLine();
+            writer.append("skippedCounter: ").append(String.valueOf(execInfo.getSkippedCount()));
+            writer.newLine();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (writer != null) {
+            writer.close();
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Issue #2 で提案されたHTMLレポート出力機能を実装しました。

## 新機能

### 1. HTMLレポート出力
- 視覚的で使いやすいインタラクティブなレポート
- 実行情報、サマリー、差分詳細を含む包括的なレポート
- 単一のHTMLファイルで完結（外部依存なし）

### 2. 実行情報の記録
- 実行開始/終了時刻、実行時間
- Old/New JARパスとファイル一覧
- Wikipedia XMLファイルパス
- 処理件数の設定

### 3. レポート形式の選択
新しいコマンドライン引数 `arg[4]` で形式を選択可能：
- `text`: テキストレポートのみ
- `html`: HTMLレポートのみ
- `both`: 両方（デフォルト）

## 実装内容

### 新規クラス
- `ExecutionInfo`: 実行情報を保持
- `ReportGenerator`: レポート生成インターフェース
- `TextReportGenerator`: テキスト形式（実行情報ヘッダー追加）
- `HtmlReportGenerator`: HTML形式

### HTMLレポートの構成

**実行情報セクション**
- 実行時刻、実行時間の表示
- JARファイル一覧（ディレクトリ指定時）
- 全ての引数情報

**サマリーセクション**
- 総処理数、差分あり件数、一致件数、スキップ件数
- 差分率と一致率をパーセンテージ表示
- カラフルなカードデザイン

**差分詳細セクション**
- 差分記事のテーブル表示
- 差分タイプ（cost/term/pos）のバッジ
- クリックで詳細を表示/非表示
- Old/Newの横並び比較

## 使用例

```bash
# HTMLとテキストの両方を生成（デフォルト）
.\gradlew runParser --args="lib/6.0.1 lib/6.2.1 data/sample.xml 100"

# HTMLのみ生成
.\gradlew runParser --args="lib/6.0.1 lib/6.2.1 data/sample.xml 100 html"

# テキストのみ生成
.\gradlew runParser --args="lib/6.0.1 lib/6.2.1 data/sample.xml 100 text"
```

## 出力ファイル
- `diff_result.html`: HTMLレポート
- `diff_result.txt`: テキストレポート

## その他の変更
- README.md: 新機能の使用方法とレポート内容の説明を追加
- PagesArticlesXmlParser: ReportGeneratorインターフェースを使用するようリファクタリング

## テスト
- ビルド成功を確認済み

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)