### PR TITLE
Wiki40bパーサーにHTMLレポート機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,15 @@ Wiki-40Bデータセットを使用する場合は、専用のパーサーを使
 - `arg[1]`: 新バージョンの JAR ファイルパスまたはディレクトリパス
 - `arg[2]` (オプション): Parquetファイルのパス（デフォルト: `./data/wiki40b-ja/train.parquet`）
 - `arg[3]` (オプション): 処理する最大件数（デフォルト: 全件処理）
+- `arg[4]` (オプション): レポート形式 (`txt`|`html`、デフォルト: `txt`)
 
 **処理件数を制限した軽量テスト：**
 ```powershell
-# 100件だけ処理
+# 100件だけ処理（テキスト形式）
 .\gradlew runWiki40bParser --args="lib/6.0.1 lib/6.2.1 ./data/wiki40b-ja/test.parquet 100"
+
+# HTMLレポート生成
+.\gradlew runWiki40bParser --args="lib/6.0.1 lib/6.2.1 ./data/wiki40b-ja/test.parquet 100 html"
 ```
 
 ## 出力結果
@@ -178,14 +182,15 @@ Wiki-40Bデータセットを使用する場合は、専用のパーサーを使
 - **テキストレポート**: `diff_result.txt` - 従来のテキスト形式
 
 ### Wiki-40B Parquetパーサー
-- `diff_result_wiki40b.txt`
+- **HTMLレポート**: `diff_result_wiki40b.html` - 視覚的で詳細なレポート（`html`形式指定時）
+- **テキストレポート**: `diff_result_wiki40b.txt` - 従来のテキスト形式（デフォルト）
 
 ### HTMLレポートの内容
 
 **実行情報セクション**
 - 実行開始/終了時刻、実行時間
 - Old/New JARパスとファイル一覧
-- Wikipedia XMLファイルパス
+- データソースパス（Wikipedia XMLまたはWiki40b Parquet）
 - 最大レコード数設定
 
 **サマリーセクション**

--- a/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
@@ -20,6 +20,14 @@ import org.apache.parquet.schema.MessageType;
 import lucene.gosen.test.util.AnalyzeResult;
 import lucene.gosen.test.util.ComponentContainer;
 import lucene.gosen.wikipedia.analyzer.WikipediaModelAnalyzer;
+import lucene.gosen.wikipedia.report.ExecutionInfo;
+import lucene.gosen.wikipedia.report.HtmlReportGenerator;
+import lucene.gosen.wikipedia.report.ReportGenerator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Wiki-40B ParquetファイルをパースしてWikipediaModelに変換するクラス
@@ -31,7 +39,7 @@ public class Wiki40bParquetParser {
     public static void main(String[] args) throws Exception {
         long start = System.currentTimeMillis();
         if (args.length < 2) {
-            System.out.println("arg[0] is old jar or directory, arg[1] is new jar or directory, [arg[2] is parquet file (default: ./data/wiki40b-ja/train.parquet)], [arg[3] is max record count (optional, default: all records)]");
+            System.out.println("arg[0] is old jar or directory, arg[1] is new jar or directory, [arg[2] is parquet file (default: ./data/wiki40b-ja/train.parquet)], [arg[3] is max record count (optional, default: all records)], [arg[4] is report format (txt or html, default: txt)]");
             System.exit(-1);
         }
 
@@ -52,11 +60,43 @@ public class Wiki40bParquetParser {
             }
         }
 
-        BufferedWriter bw = new BufferedWriter(new FileWriter("diff_result_wiki40b.txt"));
+        // Parse report format
+        String reportFormat = args.length >= 5 ? args[4].toLowerCase() : "txt";
+        if (!reportFormat.equals("txt") && !reportFormat.equals("html")) {
+            System.err.println("Error: report format must be 'txt' or 'html', got: " + reportFormat);
+            System.exit(-1);
+        }
+
+        // レポート生成の準備
+        ExecutionInfo execInfo = new ExecutionInfo();
+        execInfo.setOldJarPath(args[0]);
+        execInfo.setNewJarPath(args[1]);
+        execInfo.setDataSourcePath(parquetPath);
+        execInfo.setDataSourceType("Parquet");
+        execInfo.setMaxRecordCount(maxRecordCount);
+        execInfo.setReportFormat(reportFormat);
+        execInfo.setStartTime(new Date(start));
+
+        ReportGenerator reportGenerator = null;
+        BufferedWriter bw = null;
+
+        if ("html".equals(reportFormat)) {
+            reportGenerator = new HtmlReportGenerator();
+            reportGenerator.setExecutionInfo(execInfo);
+        } else {
+            bw = new BufferedWriter(new FileWriter("diff_result_wiki40b.txt"));
+        }
 
         System.out.println("start :: " + new Date(start));
-        ComponentContainer oldJarContainer = new ComponentContainer(getJarFiles(args[0]));
-        ComponentContainer newJarContainer = new ComponentContainer(getJarFiles(args[1]));
+        File[] oldJarFilesArray = getJarFiles(args[0]);
+        File[] newJarFilesArray = getJarFiles(args[1]);
+
+        // JAR情報をExecutionInfoに設定
+        execInfo.setOldJarFiles(Arrays.stream(oldJarFilesArray).map(File::getName).collect(Collectors.toList()));
+        execInfo.setNewJarFiles(Arrays.stream(newJarFilesArray).map(File::getName).collect(Collectors.toList()));
+
+        ComponentContainer oldJarContainer = new ComponentContainer(oldJarFilesArray);
+        ComponentContainer newJarContainer = new ComponentContainer(newJarFilesArray);
 
         WikipediaModelAnalyzer oldModelAnalyzer = (WikipediaModelAnalyzer) oldJarContainer.createComponent(
                 "lucene.gosen.wikipedia.analyzer.WikipediaModelAnalyzer", null, null);
@@ -89,7 +129,15 @@ public class Wiki40bParquetParser {
                     newModelAnalyzer.analyze(model, newJarContainer, newResult);
                     skippedCounter += skipped;
 
-                    if (compareResult(bw, model, oldResult, newResult, printToConsole)) {
+                    boolean hasDifference = false;
+                    if (reportGenerator != null) {
+                        hasDifference = compareResult(null, model, oldResult, newResult, printToConsole);
+                        reportGenerator.addDiffResult(model, oldResult, newResult, hasDifference, printToConsole);
+                    } else {
+                        hasDifference = compareResult(bw, model, oldResult, newResult, printToConsole);
+                    }
+
+                    if (hasDifference) {
                         falseCounter++;
                     }
 
@@ -99,7 +147,12 @@ public class Wiki40bParquetParser {
 
                     if (counter % 1000 == 0) {
                         System.out.println("success count:" + counter);
-                        bw.flush();
+                        if (bw != null) {
+                            bw.flush();
+                        }
+                        if (reportGenerator != null) {
+                            reportGenerator.flush();
+                        }
                     }
                     counter++;
 
@@ -111,7 +164,25 @@ public class Wiki40bParquetParser {
                 }
             }
 
-            bw.close();
+            // 処理結果をExecutionInfoに設定
+            execInfo.setTotalProcessed(counter);
+            execInfo.setDifferenceCount(falseCounter);
+            execInfo.setSkippedCount(skippedCounter);
+            execInfo.setEndTime(new Date());
+            execInfo.setDurationMs(System.currentTimeMillis() - start);
+
+            // レポート生成
+            if (bw != null) {
+                bw.close();
+            }
+
+            if (reportGenerator != null) {
+                String outputPath = "diff_result_wiki40b.html";
+                reportGenerator.generateReport(outputPath);
+                reportGenerator.close();
+                System.out.println("HTML report generated: " + outputPath);
+            }
+
             System.out.println("total processed: " + counter);
             System.out.println("falseCounter: " + falseCounter);
             System.out.println("skippedCounter: " + skippedCounter);
@@ -127,60 +198,80 @@ public class Wiki40bParquetParser {
         for (int i = 0; i < RESULT_SIZE; i++) {
             if (oldResult[i].getTotalCost() != newResult[i].getTotalCost()) {
                 String msg = "analyze result[cost] is different!!";
-                bw.append(msg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(msg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(msg);
 
                 String oldMsg = "  old[" + oldResult[i].getTotalCost() + "]";
-                bw.append(oldMsg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(oldMsg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(oldMsg);
 
                 String newMsg = "  new[" + newResult[i].getTotalCost() + "]";
-                bw.append(newMsg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(newMsg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(newMsg);
 
                 different = true;
             }
             if (different) {
                 if (i == 0) {
-                    bw.append(model.title);
+                    if (bw != null) {
+                        bw.append(model.title);
+                    }
                     if (printToConsole) System.out.println("Title: " + model.title);
                 }
             }
             if (!oldResult[i].getTermList().equals(newResult[i].getTermList())) {
                 String msg = "analyze result[termList] is different!!";
-                bw.append(msg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(msg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(msg);
 
                 String oldMsg = "  old[" + oldResult[i].getTermList().toString() + "]";
-                bw.append(oldMsg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(oldMsg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(oldMsg);
 
                 String newMsg = "  new[" + newResult[i].getTermList().toString() + "]";
-                bw.append(newMsg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(newMsg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(newMsg);
 
                 different = true;
             }
             if (!oldResult[i].getPosList().equals(newResult[i].getPosList())) {
                 String msg = "analyze result[posList] is different!!";
-                bw.append(msg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(msg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(msg);
 
                 String oldMsg = "  old[" + oldResult[i].getPosList().toString() + "]";
-                bw.append(oldMsg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(oldMsg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(oldMsg);
 
                 String newMsg = "  new[" + newResult[i].getPosList().toString() + "]";
-                bw.append(newMsg);
-                bw.newLine();
+                if (bw != null) {
+                    bw.append(newMsg);
+                    bw.newLine();
+                }
                 if (printToConsole) System.out.println(newMsg);
 
                 different = true;

--- a/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
@@ -24,7 +24,8 @@ import java.util.List;
 public class ExecutionInfo {
     private String oldJarPath;
     private String newJarPath;
-    private String xmlPath;
+    private String dataSourcePath;  // XMLまたはParquetファイルのパス
+    private String dataSourceType;  // "XML" または "Parquet"
     private int maxRecordCount;
     private String reportFormat;
     private String outputDirectory;
@@ -55,12 +56,32 @@ public class ExecutionInfo {
         this.newJarPath = newJarPath;
     }
 
-    public String getXmlPath() {
-        return xmlPath;
+    public String getDataSourcePath() {
+        return dataSourcePath;
     }
 
+    public void setDataSourcePath(String dataSourcePath) {
+        this.dataSourcePath = dataSourcePath;
+    }
+
+    public String getDataSourceType() {
+        return dataSourceType;
+    }
+
+    public void setDataSourceType(String dataSourceType) {
+        this.dataSourceType = dataSourceType;
+    }
+
+    // 後方互換性のために残す
+    @Deprecated
+    public String getXmlPath() {
+        return dataSourcePath;
+    }
+
+    @Deprecated
     public void setXmlPath(String xmlPath) {
-        this.xmlPath = xmlPath;
+        this.dataSourcePath = xmlPath;
+        this.dataSourceType = "XML";
     }
 
     public int getMaxRecordCount() {

--- a/src/main/java/lucene/gosen/wikipedia/report/HtmlReportGenerator.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/HtmlReportGenerator.java
@@ -202,7 +202,8 @@ public class HtmlReportGenerator implements ReportGenerator {
             writer.write("</td></tr>\n");
         }
 
-        writer.write("        <tr><th>Wikipedia XML</th><td>" + escapeHtml(execInfo.getXmlPath()) + "</td></tr>\n");
+        String dataSourceLabel = "Parquet".equals(execInfo.getDataSourceType()) ? "Wiki40b Parquet" : "Wikipedia XML";
+        writer.write("        <tr><th>" + dataSourceLabel + "</th><td>" + escapeHtml(execInfo.getDataSourcePath()) + "</td></tr>\n");
 
         String recordLimit = execInfo.getMaxRecordCount() > 0
                 ? execInfo.getMaxRecordCount() + " (制限あり)"


### PR DESCRIPTION
## 概要
Wiki40bParquetParserにHTMLレポート出力機能を追加し、既存のレポート生成機能を共通化しました。

## 変更内容

### 1. ExecutionInfoの拡張
- `xmlPath` → `dataSourcePath` / `dataSourceType` に変更
- XML/Parquet両方のデータソースに対応
- 後方互換性のため `@Deprecated` 付きで旧メソッドを残す

### 2. HtmlReportGeneratorの対応
- データソース種別に応じてラベルを動的に切り替え
  - Wikipedia XML / Wiki40b Parquet

### 3. Wiki40bParquetParserの機能追加
- 第5引数でレポート形式を選択可能（`txt` | `html`）
- デフォルトは `txt`（後方互換性）
- HTML形式の場合 `diff_result_wiki40b.html` を生成

### 4. READMEの更新
- Wiki40bパーサーのHTML出力方法を追記
- 実行引数の説明を更新

## 使用例

```bash
# テキスト形式（従来通り）
.\gradlew runWiki40bParser --args="lib/6.0.1 lib/6.2.1 ./data/wiki40b-ja/test.parquet 100"

# HTML形式（新機能）
.\gradlew runWiki40bParser --args="lib/6.0.1 lib/6.2.1 ./data/wiki40b-ja/test.parquet 100 html"
```

## テスト
- [ ] テキスト形式での出力確認
- [ ] HTML形式での出力確認
- [ ] Wikipedia XMLパーサーの後方互換性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)