### PR TITLE
Wiki40bパーサーのタイトル抽出処理を改善し、包括的なテストを追加

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Dfile.encoding=UTF-8
+org.gradle.console=plain

--- a/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
@@ -401,9 +401,34 @@ public class Wiki40bParquetParser {
 
         private void extractTitleFromText(String text) {
             if (text != null && !text.isEmpty()) {
-                // テキストの最初の行または最初の100文字をタイトルとして使用
-                String[] lines = text.split("\n", 2);
-                String title = lines[0].trim();
+                // テキストの各行を確認して、最初の空でない行をタイトルとして使用
+                String[] lines = text.split("\n");
+                String title = "";
+
+                for (String line : lines) {
+                    String trimmedLine = line.trim();
+                    // 空行や特殊マーカーをスキップして、最初の実質的な内容をタイトルとする
+                    if (!trimmedLine.isEmpty() &&
+                        !trimmedLine.equals("_START_ARTICLE_") &&
+                        !trimmedLine.startsWith("_START_SECTION_") &&
+                        !trimmedLine.startsWith("_START_PARAGRAPH_")) {
+                        title = trimmedLine;
+                        break;
+                    }
+                }
+
+                // タイトルが見つからない場合は最初の非空行を使用
+                if (title.isEmpty() && lines.length > 0) {
+                    for (String line : lines) {
+                        String trimmedLine = line.trim();
+                        if (!trimmedLine.isEmpty()) {
+                            title = trimmedLine;
+                            break;
+                        }
+                    }
+                }
+
+                // タイトルが100文字を超える場合は切り詰める
                 if (title.length() > 100) {
                     title = title.substring(0, 100);
                 }

--- a/src/test/java/lucene/gosen/wikipedia/Wiki40bParquetParserTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/Wiki40bParquetParserTest.java
@@ -1,6 +1,13 @@
 package lucene.gosen.wikipedia;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.io.api.PrimitiveConverter;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -61,5 +68,135 @@ class Wiki40bParquetParserTest {
         assertNotNull(converter.getConverter(0)); // wikidata_id
         assertNotNull(converter.getConverter(1)); // text
         assertNotNull(converter.getConverter(2)); // version_id
+    }
+
+    @Test
+    void testParsingTitleAndText() {
+        Wiki40bParquetParser.Wiki40bGroupConverter converter =
+            new Wiki40bParquetParser.Wiki40bGroupConverter();
+
+        // テストデータの準備
+        String testTitle = "テストタイトル";
+        String testBody = "これはテスト本文です。";
+        String testText = testTitle + "\n" + testBody;
+        String testId = "Q123456";
+
+        // パース処理をシミュレート
+        converter.start();
+
+        // wikidata_idをセット（fieldIndex=0）
+        ((PrimitiveConverter) converter.getConverter(0)).addBinary(
+            Binary.fromString(testId));
+
+        // textをセット（fieldIndex=1）
+        ((PrimitiveConverter) converter.getConverter(1)).addBinary(
+            Binary.fromString(testText));
+
+        converter.end();
+
+        // パース結果の確認
+        WikipediaModel model = converter.getCurrentRecord();
+        assertNotNull(model);
+        assertEquals(testId, model.getId());
+        assertEquals(testTitle, model.getTitle());
+        assertEquals(testText, model.getText());
+    }
+
+    @Test
+    void testParsingLongTitle() {
+        Wiki40bParquetParser.Wiki40bGroupConverter converter =
+            new Wiki40bParquetParser.Wiki40bGroupConverter();
+
+        // 100文字を超える長いタイトルをテスト
+        String longTitle = "あ".repeat(150);
+        String testBody = "本文";
+        String testText = longTitle + "\n" + testBody;
+
+        converter.start();
+        ((PrimitiveConverter) converter.getConverter(1)).addBinary(
+            Binary.fromString(testText));
+        converter.end();
+
+        WikipediaModel model = converter.getCurrentRecord();
+        assertNotNull(model);
+        // タイトルが100文字に切り詰められることを確認
+        assertEquals(100, model.getTitle().length());
+        assertEquals(longTitle.substring(0, 100), model.getTitle());
+        assertEquals(testText, model.getText());
+    }
+
+    @Test
+    void testParsingEmptyText() {
+        Wiki40bParquetParser.Wiki40bGroupConverter converter =
+            new Wiki40bParquetParser.Wiki40bGroupConverter();
+
+        converter.start();
+        ((PrimitiveConverter) converter.getConverter(1)).addBinary(
+            Binary.fromString(""));
+        converter.end();
+
+        WikipediaModel model = converter.getCurrentRecord();
+        assertNotNull(model);
+        assertEquals("", model.getText());
+    }
+
+    @Test
+    void testReadActualParquetFile() throws Exception {
+        // テスト用のParquetファイルパス
+        String testParquetPath = "./data/wiki40b-ja/test.parquet";
+        File testFile = new File(testParquetPath);
+
+        // ファイルが存在しない場合はスキップ
+        if (!testFile.exists()) {
+            System.out.println("Test parquet file not found, skipping test: " + testParquetPath);
+            return;
+        }
+
+        Configuration conf = new Configuration();
+        Path path = new Path(testParquetPath);
+
+        // 最初の3レコードを読み込んでパース結果を検証
+        try (ParquetReader<WikipediaModel> reader = ParquetReader.builder(
+                new Wiki40bParquetParser.Wiki40bReadSupport(), path)
+                .withConf(conf)
+                .build()) {
+
+            int recordCount = 0;
+            int maxRecords = 3;
+            WikipediaModel model;
+
+            while ((model = reader.read()) != null && recordCount < maxRecords) {
+                // 基本的な検証
+                assertNotNull(model, "Model should not be null");
+
+                System.out.println("\n=== Record #" + (recordCount + 1) + " ===");
+                System.out.println("ID: " + (model.getId() != null ? model.getId() : "(null)"));
+                System.out.println("Title: " + (model.getTitle() != null ? "\"" + model.getTitle() + "\"" : "(null)"));
+                System.out.println("Text: " + (model.getText() != null ? "\"" + model.getText() + "\"" : "(null)"));
+                System.out.println("Text length: " + (model.getText() != null ? model.getText().length() : 0));
+
+                // テキストが空でない場合のみ、詳細な検証を行う
+                if (model.getText() != null && !model.getText().isEmpty()) {
+                    // IDが設定されていることを確認
+                    assertNotNull(model.getId(), "ID should not be null");
+
+                    // タイトルが設定されていることを確認
+                    assertNotNull(model.getTitle(), "Title should not be null when text is not empty");
+                    assertFalse(model.getTitle().isEmpty(), "Title should not be empty when text is not empty");
+
+                    // タイトルの長さが100文字以下であることを確認
+                    assertTrue(model.getTitle().length() <= 100,
+                        "Title length should be <= 100, but was " + model.getTitle().length());
+
+                    recordCount++;
+                } else {
+                    System.out.println("(Skipping record with empty text)");
+                }
+            }
+
+            // 少なくとも1レコードは読み込めたことを確認
+            assertTrue(recordCount > 0, "Should read at least one record from parquet file");
+            System.out.println("\nSuccessfully read " + recordCount + " records from parquet file");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Wiki40bパーサーのタイトル抽出ロジックを改善
  - 空行と特殊マーカー（`_START_ARTICLE_`、`_START_SECTION_`、`_START_PARAGRAPH_`）をスキップ
  - 実際のコンテンツ行を正しくタイトルとして抽出
- 4つの新しいテストケースを追加
  - `testParsingTitleAndText`: タイトルとテキストのパース検証
  - `testParsingLongTitle`: 長いタイトル（150文字）が100文字に切り詰められることを検証
  - `testParsingEmptyText`: 空テキストの処理検証
  - `testReadActualParquetFile`: 実際のParquetファイルから3レコードを読み込んでパース結果を検証

## 変更内容

### Wiki40bParquetParser.java
`extractTitleFromText`メソッドを改善し、Wiki40bデータセット特有の特殊マーカーや空行をスキップして、実際のタイトル文字列を正しく抽出できるようにしました。

### Wiki40bParquetParserTest.java
以下の4つのテストを追加:
1. 基本的なタイトルとテキストのパース検証
2. 長いタイトルの切り詰め処理の検証
3. 空テキストの処理検証
4. 実際のParquetファイルからの読み込み検証（`./data/wiki40b-ja/test.parquet`が存在する場合）

## Test plan
- [x] すべての既存テストが成功することを確認
- [x] 新しく追加した4つのテストがすべて成功することを確認
- [x] 実際のParquetファイルから正しくタイトルとテキストが抽出できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)