### PR TITLE
Add Picocli command-line options and robust error handling

### DIFF
--- a/src/main/java/lucene/gosen/wikipedia/AbstractWikipediaParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/AbstractWikipediaParser.java
@@ -21,6 +21,7 @@ import lucene.gosen.wikipedia.report.HtmlReportGenerator;
 import lucene.gosen.wikipedia.report.ReportGenerator;
 import lucene.gosen.wikipedia.report.TextReportGenerator;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -40,15 +41,19 @@ public abstract class AbstractWikipediaParser {
     public void execute(ParserConfig config) throws Exception {
         long start = System.currentTimeMillis();
 
+        // JARファイルを取得
+        File[] oldJarFiles = ParserUtils.getJarFiles(config.getOldJarPath());
+        File[] newJarFiles = ParserUtils.getJarFiles(config.getNewJarPath());
+
         // AnalyzerContainerManagerを作成
         AnalyzerContainerManager analyzerManager = new AnalyzerContainerManager(
-                config.getOldJarPath(), config.getNewJarPath());
+                oldJarFiles, newJarFiles);
 
         // 実行情報を構築
         ExecutionInfo execInfo = ParserUtils.buildExecutionInfo(
                 config,
-                ParserUtils.getJarFiles(config.getOldJarPath()),
-                ParserUtils.getJarFiles(config.getNewJarPath()),
+                oldJarFiles,
+                newJarFiles,
                 getDataSourceType(),
                 start);
 
@@ -75,42 +80,49 @@ public abstract class AbstractWikipediaParser {
             WikipediaModel model;
             while ((model = readNextModel(dataSource)) != null) {
                 if (shouldProcessModel(model)) {
-                    // 解析実行
-                    int skipped = analyzerManager.getOldModelAnalyzer().analyze(
-                            model, analyzerManager.getOldJarContainer(), oldResult);
-                    analyzerManager.getNewModelAnalyzer().analyze(
-                            model, analyzerManager.getNewJarContainer(), newResult);
-                    skippedCounter += skipped;
+                    try {
+                        // 解析実行
+                        int skipped = analyzerManager.getOldModelAnalyzer().analyze(
+                                model, analyzerManager.getOldJarContainer(), oldResult);
+                        analyzerManager.getNewModelAnalyzer().analyze(
+                                model, analyzerManager.getNewJarContainer(), newResult);
+                        skippedCounter += skipped;
 
-                    // 結果比較
-                    boolean hasDifference = ParserUtils.compareResult(oldResult, newResult, RESULT_SIZE);
-                    if (hasDifference) {
-                        falseCounter++;
-                    }
-
-                    // レポートに結果を追加
-                    for (ReportGenerator generator : reportGenerators) {
-                        generator.addDiffResult(model, oldResult, newResult, hasDifference, printToConsole);
-                    }
-
-                    // コンソール出力
-                    if (printToConsole) {
-                        ParserUtils.printResults(counter, model, oldResult, newResult);
-                    }
-
-                    // 定期的なフラッシュ
-                    if (counter % 1000 == 0) {
-                        System.out.println("success count:" + counter);
-                        for (ReportGenerator generator : reportGenerators) {
-                            generator.flush();
+                        // 結果比較
+                        boolean hasDifference = ParserUtils.compareResult(oldResult, newResult, RESULT_SIZE);
+                        if (hasDifference) {
+                            falseCounter++;
                         }
-                    }
-                    counter++;
 
-                    // 最大レコード数チェック
-                    if (config.getMaxRecordCount() > 0 && counter >= config.getMaxRecordCount()) {
-                        System.out.println("Reached max record count: " + config.getMaxRecordCount());
-                        break;
+                        // レポートに結果を追加
+                        for (ReportGenerator generator : reportGenerators) {
+                            generator.addDiffResult(model, oldResult, newResult, hasDifference, printToConsole);
+                        }
+
+                        // コンソール出力
+                        if (printToConsole) {
+                            ParserUtils.printResults(counter, model, oldResult, newResult);
+                        }
+
+                        // 定期的なフラッシュ
+                        if (counter % 1000 == 0) {
+                            System.out.println("success count:" + counter);
+                            for (ReportGenerator generator : reportGenerators) {
+                                generator.flush();
+                            }
+                        }
+                        counter++;
+
+                        // 最大レコード数チェック
+                        if (config.getMaxRecordCount() > 0 && counter >= config.getMaxRecordCount()) {
+                            System.out.println("Reached max record count: " + config.getMaxRecordCount());
+                            break;
+                        }
+                    } catch (Exception e) {
+                        System.err.println("Error processing record #" + (counter + 1) +
+                                (model.getTitle() != null ? " (Title: " + model.getTitle() + ")" : "") +
+                                ": " + e.getMessage());
+                        // Continue processing next record
                     }
                 }
             }

--- a/src/main/java/lucene/gosen/wikipedia/AnalyzerContainerManager.java
+++ b/src/main/java/lucene/gosen/wikipedia/AnalyzerContainerManager.java
@@ -29,10 +29,7 @@ public class AnalyzerContainerManager {
     private final WikipediaModelAnalyzer oldModelAnalyzer;
     private final WikipediaModelAnalyzer newModelAnalyzer;
 
-    public AnalyzerContainerManager(String oldJarPath, String newJarPath) throws ClassNotFoundException {
-        File[] oldJarFiles = ParserUtils.getJarFiles(oldJarPath);
-        File[] newJarFiles = ParserUtils.getJarFiles(newJarPath);
-
+    public AnalyzerContainerManager(File[] oldJarFiles, File[] newJarFiles) throws ClassNotFoundException {
         this.oldJarContainer = new ComponentContainer(oldJarFiles);
         this.newJarContainer = new ComponentContainer(newJarFiles);
 

--- a/src/main/java/lucene/gosen/wikipedia/PagesArticlesXmlParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/PagesArticlesXmlParser.java
@@ -115,11 +115,29 @@ public class PagesArticlesXmlParser extends AbstractWikipediaParser implements C
     @Override
     protected WikipediaModel readNextModel(Object dataSource) throws Exception {
         XMLEventReader reader = (XMLEventReader) dataSource;
-        while (reader.hasNext()) {
-            XMLEvent event = reader.nextEvent();
-            if (isStartElem(event, "page")) {
-                return pageParse(reader);
+        try {
+            while (reader.hasNext()) {
+                XMLEvent event = reader.nextEvent();
+                if (isStartElem(event, "page")) {
+                    WikipediaModel model = pageParse(reader);
+                    // スキップすべきページ（nullが返される）の場合は次のページを探す
+                    if (model != null) {
+                        return model;
+                    }
+                    // model == null の場合は continue して次の <page> を探す
+                }
             }
+        } catch (com.ctc.wstx.exc.WstxIOException e) {
+            System.err.println("Warning: Unexpected end of XML stream. The input file may be truncated or corrupted.");
+            System.err.println("Error details: " + e.getMessage());
+            return null; // Signal end of processing
+        } catch (javax.xml.stream.XMLStreamException e) {
+            if (e.getCause() instanceof java.io.IOException) {
+                System.err.println("Warning: IO error while reading XML stream. The input file may be incomplete.");
+                System.err.println("Error details: " + e.getMessage());
+                return null; // Signal end of processing
+            }
+            throw e; // Re-throw other XML stream exceptions
         }
         return null;
     }
@@ -207,13 +225,19 @@ public class PagesArticlesXmlParser extends AbstractWikipediaParser implements C
     private static String getText(XMLEventReader reader, String name)
             throws Exception {
         StringBuilder builder = new StringBuilder();
-        while (reader.hasNext()) {
-            XMLEvent event = reader.nextEvent();
-            if (isEndElem(event, name)) break;
-            else if (event.getEventType() == XMLStreamConstants.CHARACTERS) {
-                String data = event.asCharacters().getData().trim();
-                if (!data.isEmpty()) builder.append(data);
+        try {
+            while (reader.hasNext()) {
+                XMLEvent event = reader.nextEvent();
+                if (isEndElem(event, name)) break;
+                else if (event.getEventType() == XMLStreamConstants.CHARACTERS) {
+                    String data = event.asCharacters().getData().trim();
+                    if (!data.isEmpty()) builder.append(data);
+                }
             }
+        } catch (com.ctc.wstx.exc.WstxIOException e) {
+            // Stream ended unexpectedly while reading element content
+            System.err.println("Warning: Stream ended while reading <" + name + "> element");
+            // Return whatever was collected so far
         }
         return builder.toString();
     }


### PR DESCRIPTION
## Summary
- Add Picocli for named command-line options across all tools
- Add robust error handling for corrupted or incomplete Wikipedia dump files
- Improve code structure by refactoring JAR file handling

## Changes

### 1. Picocli Integration
- Migrated all command-line tools to use Picocli for better usability
- All tools now support `--help` and `--version` options
- Named options replace positional arguments for clarity

### 2. Error Handling Improvements
- Add graceful handling of `WstxIOException` and `XMLStreamException` in XML parsing
- Add error handling for individual record processing failures
- Add warning messages when encountering truncated or corrupted input files
- Parser continues processing when encountering stream errors instead of crashing

### 3. Code Refactoring
- Refactor `AnalyzerContainerManager` to accept `File[]` directly
- Reduce duplicate `getJarFiles()` calls in `AbstractWikipediaParser`
- Improve separation of concerns

## Test plan
- [ ] Test with valid Wikipedia XML dump file
- [ ] Test with corrupted/truncated bzip2 file (should show warnings but not crash)
- [ ] Test `--help` option on all commands
- [ ] Test with Wiki-40B parquet files
- [ ] Verify backward compatibility with existing workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)