### PR TITLE
Validate parquet inputs and harden wiki40b downloads

### DIFF
--- a/src/main/java/lucene/gosen/wikipedia/ParquetFileValidator.java
+++ b/src/main/java/lucene/gosen/wikipedia/ParquetFileValidator.java
@@ -1,0 +1,75 @@
+package lucene.gosen.wikipedia;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Parquetファイルの妥当性を簡易検証するユーティリティ.
+ */
+public final class ParquetFileValidator {
+
+    private static final String PARQUET_MAGIC = "PAR1";
+    private static final int MAGIC_SIZE = 4;
+    private static final int MIN_PARQUET_SIZE = 8;
+
+    private ParquetFileValidator() {
+    }
+
+    /**
+     * 入力パスが読み取り可能で、Parquetのマジックバイトを持つことを検証する.
+     *
+     * @throws IOException 検証に失敗した場合
+     */
+    public static void assertReadableParquetFile(Path path) throws IOException {
+        if (path == null) {
+            throw new IOException("Input parquet path is null");
+        }
+        if (!Files.exists(path)) {
+            throw new IOException("Input parquet file does not exist: " + path.toAbsolutePath());
+        }
+        if (!Files.isRegularFile(path)) {
+            throw new IOException("Input parquet path is not a regular file: " + path.toAbsolutePath());
+        }
+        if (!Files.isReadable(path)) {
+            throw new IOException("Input parquet file is not readable: " + path.toAbsolutePath());
+        }
+
+        long size = Files.size(path);
+        if (size < MIN_PARQUET_SIZE) {
+            throw new IOException("Input parquet file is too small (" + size + " bytes): " + path.toAbsolutePath());
+        }
+
+        try (RandomAccessFile raf = new RandomAccessFile(path.toFile(), "r")) {
+            byte[] header = new byte[MAGIC_SIZE];
+            raf.readFully(header);
+
+            raf.seek(size - MAGIC_SIZE);
+            byte[] footer = new byte[MAGIC_SIZE];
+            raf.readFully(footer);
+
+            String headerMagic = new String(header, StandardCharsets.US_ASCII);
+            String footerMagic = new String(footer, StandardCharsets.US_ASCII);
+
+            if (!PARQUET_MAGIC.equals(headerMagic) || !PARQUET_MAGIC.equals(footerMagic)) {
+                throw new IOException(
+                        "File is not a valid Parquet file (expected PAR1 magic at header/footer): "
+                                + path.toAbsolutePath());
+            }
+        }
+    }
+
+    /**
+     * Parquetとして読める可能性が高いかを返す.
+     */
+    public static boolean isLikelyParquetFile(Path path) {
+        try {
+            assertReadableParquetFile(path);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/lucene/gosen/wikipedia/Wiki40bDownloader.java
+++ b/src/main/java/lucene/gosen/wikipedia/Wiki40bDownloader.java
@@ -5,14 +5,18 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 import java.io.BufferedInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.concurrent.Callable;
 
 /**
@@ -111,19 +115,38 @@ public class Wiki40bDownloader implements Callable<Integer> {
      */
     private static void downloadFile(String urlString, String destString) throws IOException {
         Path destPath = Paths.get(destString);
+        Path tempPath = Paths.get(destString + ".part");
 
-        // 既に存在する場合はスキップ
+        // 既存ファイルが有効なParquetならスキップ
         if (Files.exists(destPath)) {
-            System.out.println("File already exists, skipping: " + destPath.getFileName());
-            return;
+            if (ParquetFileValidator.isLikelyParquetFile(destPath)) {
+                System.out.println("Valid parquet file already exists, skipping: " + destPath.getFileName());
+                return;
+            }
+            System.out.println("Existing file is invalid parquet, re-downloading: " + destPath.getFileName());
+            Files.delete(destPath);
+        }
+
+        if (Files.exists(tempPath)) {
+            Files.delete(tempPath);
         }
 
         System.out.println("Downloading from: " + urlString);
         System.out.println("To: " + destPath.toAbsolutePath());
 
         URL url = URI.create(urlString).toURL();
-        try (InputStream in = new BufferedInputStream(url.openStream());
-             FileOutputStream out = new FileOutputStream(destPath.toFile())) {
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setConnectTimeout(30_000);
+        connection.setReadTimeout(300_000);
+        connection.setRequestMethod("GET");
+        connection.connect();
+        int status = connection.getResponseCode();
+        if (status < 200 || status >= 300) {
+            throw new IOException("Failed to download file. HTTP status: " + status + " from " + urlString);
+        }
+
+        try (InputStream in = new BufferedInputStream(connection.getInputStream());
+             FileOutputStream out = new FileOutputStream(tempPath.toFile())) {
 
             byte[] dataBuffer = new byte[65536]; // 64KB buffer
             int bytesRead;
@@ -141,6 +164,18 @@ public class Wiki40bDownloader implements Callable<Integer> {
                 }
             }
             System.out.printf("Download completed! Total size: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
+        } catch (FileNotFoundException e) {
+            throw new IOException("Download returned no file content: " + urlString, e);
+        } finally {
+            connection.disconnect();
         }
+
+        ParquetFileValidator.assertReadableParquetFile(tempPath);
+        try {
+            Files.move(tempPath, destPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(tempPath, destPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+        System.out.println("Saved validated parquet file: " + destPath.toAbsolutePath());
     }
 }

--- a/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/Wiki40bParquetParser.java
@@ -10,6 +10,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import java.nio.file.Paths;
 import java.util.concurrent.Callable;
 
 /**
@@ -99,6 +100,15 @@ public class Wiki40bParquetParser extends AbstractWikipediaParser implements Cal
 
     @Override
     protected Object initializeDataSource(ParserConfig config) throws Exception {
+        try {
+            ParquetFileValidator.assertReadableParquetFile(Paths.get(config.getInputPath()));
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Invalid parquet input: " + config.getInputPath()
+                            + ". The file may be incomplete or not parquet. "
+                            + "Delete the file and re-download it with runWiki40bDownload.", e);
+        }
+
         Configuration conf = new Configuration();
         Path path = new Path(config.getInputPath());
         parquetReader = ParquetReader.builder(new Wiki40bReadSupport(), path)

--- a/src/test/java/lucene/gosen/wikipedia/ParquetFileValidatorTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/ParquetFileValidatorTest.java
@@ -1,0 +1,36 @@
+package lucene.gosen.wikipedia;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ParquetFileValidatorTest {
+
+    @Test
+    void testAssertReadableParquetFileWithValidMagic(@TempDir Path tempDir) throws IOException {
+        Path parquet = tempDir.resolve("valid.parquet");
+        byte[] content = "PAR1payloadPAR1".getBytes(StandardCharsets.US_ASCII);
+        Files.write(parquet, content);
+
+        assertDoesNotThrow(() -> ParquetFileValidator.assertReadableParquetFile(parquet));
+        assertTrue(ParquetFileValidator.isLikelyParquetFile(parquet));
+    }
+
+    @Test
+    void testAssertReadableParquetFileWithInvalidMagic(@TempDir Path tempDir) throws IOException {
+        Path broken = tempDir.resolve("broken.parquet");
+        Files.write(broken, "<html>not parquet</html>".getBytes(StandardCharsets.US_ASCII));
+
+        assertThrows(IOException.class, () -> ParquetFileValidator.assertReadableParquetFile(broken));
+        assertFalse(ParquetFileValidator.isLikelyParquetFile(broken));
+    }
+}


### PR DESCRIPTION
## Summary
- add parquet file validator to check PAR1 magic and basic file readability
- validate parquet input before parser starts and fail with actionable error
- harden downloader to re-download invalid existing files, download via .part, validate, then move into place
- add unit tests for parquet validator

## Verification
- .\gradlew test --tests "lucene.gosen.wikipedia.ParquetFileValidatorTest" --tests "lucene.gosen.wikipedia.Wiki40bParquetParserTest" --tests "lucene.gosen.wikipedia.Wiki40bDownloaderTest"
