### PR TITLE
Fix #33: analyzer IO失敗を握りつぶさず失敗件数を集計

### DIFF
--- a/src/main/java/lucene/gosen/wikipedia/AbstractWikipediaParser.java
+++ b/src/main/java/lucene/gosen/wikipedia/AbstractWikipediaParser.java
@@ -77,6 +77,7 @@ public abstract class AbstractWikipediaParser {
         int counter = 0;
         int falseCounter = 0;
         int skippedCounter = 0;
+        int failedCounter = 0;
         boolean printToConsole = config.shouldPrintToConsole();
         int workerCount = config.getWorkerCount();
         int queueSize = config.getQueueSize();
@@ -133,6 +134,7 @@ public abstract class AbstractWikipediaParser {
                     nextSeqToEmit++;
 
                     if (record.error() != null) {
+                        failedCounter++;
                         System.err.println("Error processing record #" + (counter + 1) +
                                 (record.model().getTitle() != null ? " (Title: " + record.model().getTitle() + ")" : "") +
                                 ": " + record.error().getMessage());
@@ -173,7 +175,7 @@ public abstract class AbstractWikipediaParser {
         }
 
         // 実行情報の最終更新
-        ParserUtils.finalizeExecutionInfo(execInfo, counter, falseCounter, skippedCounter, start);
+        ParserUtils.finalizeExecutionInfo(execInfo, counter, falseCounter, skippedCounter, failedCounter, start);
 
         // レポート生成
         generateReports(reportGenerators);
@@ -182,6 +184,7 @@ public abstract class AbstractWikipediaParser {
         System.out.println("total processed: " + counter);
         System.out.println("falseCounter: " + falseCounter);
         System.out.println("skippedCounter: " + skippedCounter);
+        System.out.println("failedCounter: " + failedCounter);
         System.out.println((System.currentTimeMillis() - start) + "msec");
     }
 

--- a/src/main/java/lucene/gosen/wikipedia/ParserUtils.java
+++ b/src/main/java/lucene/gosen/wikipedia/ParserUtils.java
@@ -143,15 +143,17 @@ public class ParserUtils {
      * @param counter        処理済みカウント
      * @param falseCounter   差分カウント
      * @param skippedCounter スキップカウント
+     * @param failedCounter  失敗カウント
      * @param startTime      開始時刻
      */
     public static void finalizeExecutionInfo(ExecutionInfo execInfo, int counter, int falseCounter,
-                                             int skippedCounter, long startTime) {
+                                             int skippedCounter, int failedCounter, long startTime) {
         execInfo.setEndTime(new Date());
         execInfo.setDurationMs(System.currentTimeMillis() - startTime);
         execInfo.setTotalProcessed(counter);
         execInfo.setDifferenceCount(falseCounter);
         execInfo.setSkippedCount(skippedCounter);
+        execInfo.setFailedCount(failedCounter);
     }
 
     /**

--- a/src/main/java/lucene/gosen/wikipedia/analyzer/WikipediaModelAnalyzer.java
+++ b/src/main/java/lucene/gosen/wikipedia/analyzer/WikipediaModelAnalyzer.java
@@ -37,7 +37,7 @@ public class WikipediaModelAnalyzer {
         return (titleSkipped && textSkipped) ? 1 : 0;
     }
 
-    private boolean analyze(ComponentContainer container, String target, AnalyzeResult result) throws IllegalArgumentException, SecurityException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    private boolean analyze(ComponentContainer container, String target, AnalyzeResult result) throws IllegalArgumentException, SecurityException, IllegalAccessException, InvocationTargetException, NoSuchMethodException, IOException {
         result.reset();
 
         // Skip empty strings
@@ -70,9 +70,6 @@ public class WikipediaModelAnalyzer {
         } catch (ClassNotFoundException cnfe) {
             System.err.println("ClassNotFound!!!");
             throw new RuntimeException(cnfe);
-        } catch (IOException ioe) {
-            System.err.println("target:[" + target + "]");
-            ioe.printStackTrace();
         }
         return false; // not skipped
     }

--- a/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
@@ -39,6 +39,7 @@ public class ExecutionInfo {
     private int totalProcessed;
     private int differenceCount;
     private int skippedCount;
+    private int failedCount;
 
     public String getOldJarPath() {
         return oldJarPath;
@@ -170,5 +171,13 @@ public class ExecutionInfo {
 
     public void setSkippedCount(int skippedCount) {
         this.skippedCount = skippedCount;
+    }
+
+    public int getFailedCount() {
+        return failedCount;
+    }
+
+    public void setFailedCount(int failedCount) {
+        this.failedCount = failedCount;
     }
 }

--- a/src/main/java/lucene/gosen/wikipedia/report/HtmlReportGenerator.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/HtmlReportGenerator.java
@@ -245,6 +245,11 @@ public class HtmlReportGenerator implements ReportGenerator {
         writer.write("        <div class=\"number\">" + execInfo.getSkippedCount() + "</div>\n");
         writer.write("      </div>\n");
 
+        writer.write("      <div class=\"summary-card warning\">\n");
+        writer.write("        <div class=\"label\">失敗</div>\n");
+        writer.write("        <div class=\"number\">" + execInfo.getFailedCount() + "</div>\n");
+        writer.write("      </div>\n");
+
         writer.write("    </div>\n");
     }
 

--- a/src/main/java/lucene/gosen/wikipedia/report/TextReportGenerator.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/TextReportGenerator.java
@@ -225,6 +225,8 @@ public class TextReportGenerator implements ReportGenerator {
             writer.newLine();
             writer.append("skippedCounter: ").append(String.valueOf(execInfo.getSkippedCount()));
             writer.newLine();
+            writer.append("failedCounter: ").append(String.valueOf(execInfo.getFailedCount()));
+            writer.newLine();
         }
     }
 

--- a/src/test/java/lucene/gosen/wikipedia/report/HtmlReportGeneratorTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/report/HtmlReportGeneratorTest.java
@@ -37,6 +37,7 @@ class HtmlReportGeneratorTest {
         info.setTotalProcessed(1);
         info.setDifferenceCount(1);
         info.setSkippedCount(0);
+        info.setFailedCount(2);
         generator.setExecutionInfo(info);
     }
 
@@ -58,6 +59,8 @@ class HtmlReportGeneratorTest {
         assertTrue(html.contains("差分詳細 (1件)"));
         assertTrue(html.contains("記事タイトル"));
         assertTrue(html.contains("diff-type cost"));
+        assertTrue(html.contains("失敗"));
+        assertTrue(html.contains(">2<"));
     }
 
     @Test

--- a/src/test/java/lucene/gosen/wikipedia/report/TextReportGeneratorTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/report/TextReportGeneratorTest.java
@@ -161,4 +161,27 @@ class TextReportGeneratorTest {
         int costPos = content.indexOf("analyze result[cost] is different!!");
         assertTrue(titlePos < costPos, "タイトルが差分詳細より前に出力されること");
     }
+
+    @Test
+    void testSummaryIncludesFailedCounter() throws IOException {
+        ExecutionInfo info = new ExecutionInfo();
+        info.setOldJarPath("old.jar");
+        info.setNewJarPath("new.jar");
+        info.setXmlPath("input.xml");
+        info.setTotalProcessed(10);
+        info.setDifferenceCount(3);
+        info.setSkippedCount(2);
+        info.setFailedCount(1);
+        generator.setExecutionInfo(info);
+
+        WikipediaModel model = createModel("テスト記事", "本文テキスト");
+        AnalyzeResult[] oldResults = createResults(100, "旧単語", "名詞");
+        AnalyzeResult[] newResults = createResults(200, "新単語", "名詞");
+        generator.addDiffResult(model, oldResults, newResults, true, false);
+        generator.generateReport(outputFile.toString());
+        generator.flush();
+
+        String content = Files.readString(outputFile);
+        assertTrue(content.contains("failedCounter: 1"), "サマリーにfailedCounterが出力されること");
+    }
 }


### PR DESCRIPTION
## 概要
Issue #33 に対応し、`WikipediaModelAnalyzer` の `IOException` を握りつぶさず呼び出し元へ伝播し、失敗レコードを明示的に集計するようにしました。

## 変更内容
- `WikipediaModelAnalyzer`
  - `catch (IOException)` による `printStackTrace()` を削除
  - `IOException` を上位へ伝播
- `AbstractWikipediaParser`
  - `failedCounter` を追加
  - `record.error() != null` の場合に `failedCounter++` して結果を不採用
  - 終了時統計に `failedCounter` を追加
- `ExecutionInfo`
  - `failedCount` フィールドを追加
- `ParserUtils.finalizeExecutionInfo(...)`
  - `failedCounter` を受け取り `ExecutionInfo` に反映
- レポート
  - Text: サマリーに `failedCounter` を追加
  - HTML: サマリーカードに「失敗」を追加
- テスト
  - Text/HTML レポートテストに `failedCount` 表示の検証を追加

## 確認状況
- この実行環境では `JAVA_HOME` 未設定のためテスト未実行

Closes #33