### PR TITLE
Issue #37: Encapsulate WikipediaModel and remove unused field

### DIFF
--- a/src/main/java/lucene/gosen/wikipedia/WikipediaModel.java
+++ b/src/main/java/lucene/gosen/wikipedia/WikipediaModel.java
@@ -5,12 +5,11 @@ import java.util.Date;
 
 public class WikipediaModel {
 
-    String title;
-    String titleAnnotation;
-    String id;
-    String text;
-    int textCount;
-    Date lastModified;
+    private String title;
+    private String titleAnnotation;
+    private String id;
+    private String text;
+    private Date lastModified;
 
     public String getId() {
         return id;
@@ -52,6 +51,7 @@ public class WikipediaModel {
         this.lastModified = lastModified;
     }
 
+    @Override
     public String toString() {
         return this.id + "," + this.title + "," + this.titleAnnotation + "," + this.lastModified;
     }


### PR DESCRIPTION
## Summary
- make `WikipediaModel` fields private to tighten encapsulation
- remove unused `textCount` field
- add `@Override` to `toString()` for clarity

## Verification
- local tests were confirmed by user as passing

Closes #37