### PR TITLE
Fix #35: secure XML parser configuration for POM parsing

### DIFF
--- a/src/main/java/lucene/gosen/wikipedia/MavenJarDownloader.java
+++ b/src/main/java/lucene/gosen/wikipedia/MavenJarDownloader.java
@@ -7,6 +7,7 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.BufferedInputStream;
@@ -122,8 +123,20 @@ public class MavenJarDownloader implements Callable<Integer> {
         try {
             URL url = URI.create(pomUrl).toURL();
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
             DocumentBuilder builder = factory.newDocumentBuilder();
-            Document doc = builder.parse(url.openStream());
+            Document doc;
+            try (InputStream pomStream = url.openStream()) {
+                doc = builder.parse(pomStream);
+            }
 
             // dependenciesセクションからlucene-coreを探す
             NodeList dependencies = doc.getElementsByTagName("dependency");

--- a/src/test/java/lucene/gosen/wikipedia/MavenJarDownloaderTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/MavenJarDownloaderTest.java
@@ -4,12 +4,29 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class MavenJarDownloaderTest {
+
+    private String invokeExtractLuceneCoreVersion(String pomUrl, String defaultVersion) throws Exception {
+        Method method = MavenJarDownloader.class.getDeclaredMethod("extractLuceneCoreVersion", String.class, String.class);
+        method.setAccessible(true);
+        try {
+            return (String) method.invoke(null, pomUrl, defaultVersion);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception exception) {
+                throw exception;
+            }
+            throw e;
+        }
+    }
 
     @Test
     void testConstants() {
@@ -137,5 +154,50 @@ class MavenJarDownloaderTest {
             assertNotNull(args[0]); // version
             assertNotNull(args[1]); // destination
         });
+    }
+
+    @Test
+    void testExtractLuceneCoreVersionWithValidPom(@TempDir Path tempDir) throws Exception {
+        Path pomFile = tempDir.resolve("valid.pom");
+        String pomContent = """
+                <project>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.lucene</groupId>
+                      <artifactId>lucene-core</artifactId>
+                      <version>9.10.0</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        Files.writeString(pomFile, pomContent, StandardCharsets.UTF_8);
+
+        String actualVersion = invokeExtractLuceneCoreVersion(pomFile.toUri().toString(), "6.2.1");
+
+        assertEquals("9.10.0", actualVersion);
+    }
+
+    @Test
+    void testExtractLuceneCoreVersionWithDoctypeFallsBack(@TempDir Path tempDir) throws Exception {
+        Path pomFile = tempDir.resolve("doctype.pom");
+        String pomContent = """
+                <!DOCTYPE project [
+                  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+                ]>
+                <project>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.apache.lucene</groupId>
+                      <artifactId>lucene-core</artifactId>
+                      <version>&xxe;</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        Files.writeString(pomFile, pomContent, StandardCharsets.UTF_8);
+
+        String actualVersion = invokeExtractLuceneCoreVersion(pomFile.toUri().toString(), "6.2.1");
+
+        assertEquals("6.2.1", actualVersion);
     }
 }


### PR DESCRIPTION
## Summary
- Harden `MavenJarDownloader#extractLuceneCoreVersion` XML parsing against XXE
- Add explicit secure `DocumentBuilderFactory` features/attributes
- Read POM with try-with-resources so stream is always closed
- Keep existing fallback behavior to `defaultVersion` on parse/config failure
- Add tests for valid POM extraction and DOCTYPE-based fallback

## Changes
- `disallow-doctype-decl=true`
- `external-general-entities=false`
- `external-parameter-entities=false`
- `load-external-dtd=false`
- `FEATURE_SECURE_PROCESSING=true`
- `ACCESS_EXTERNAL_DTD=""`
- `ACCESS_EXTERNAL_SCHEMA=""`
- `setXIncludeAware(false)`
- `setExpandEntityReferences(false)`

## Test
- `MavenJarDownloaderTest#testExtractLuceneCoreVersionWithValidPom`
- `MavenJarDownloaderTest#testExtractLuceneCoreVersionWithDoctypeFallsBack`

Closes #35
