### PR TITLE
Fix #36: remove unused ParserUtils APIs and unused ExecutionInfo fields

### DIFF
--- a/src/main/java/lucene/gosen/wikipedia/ParserUtils.java
+++ b/src/main/java/lucene/gosen/wikipedia/ParserUtils.java
@@ -129,7 +129,6 @@ public class ParserUtils {
         execInfo.setDataSourcePath(config.getInputPath());
         execInfo.setDataSourceType(dataSourceType);
         execInfo.setMaxRecordCount(config.getMaxRecordCount());
-        execInfo.setReportFormat(config.getReportFormat());
         execInfo.setStartTime(new Date(startTime));
         execInfo.setOldJarFiles(Arrays.stream(oldJarFiles).map(File::getName).toList());
         execInfo.setNewJarFiles(Arrays.stream(newJarFiles).map(File::getName).toList());
@@ -156,45 +155,4 @@ public class ParserUtils {
         execInfo.setFailedCount(failedCounter);
     }
 
-    /**
-     * コマンドライン引数からmaxRecordCountをパースする
-     *
-     * @param args           コマンドライン引数配列
-     * @param argIndex       解析する引数のインデックス
-     * @param defaultValue   デフォルト値
-     * @return パース済みのmaxRecordCount（-1は無制限を意味する）
-     */
-    public static int parseMaxRecordCount(String[] args, int argIndex, int defaultValue) {
-        int maxRecordCount = defaultValue;
-        if (args.length > argIndex) {
-            try {
-                maxRecordCount = Integer.parseInt(args[argIndex]);
-                if (maxRecordCount <= 0) {
-                    System.err.println("Error: max record count must be a positive number");
-                    System.exit(-1);
-                }
-            } catch (NumberFormatException e) {
-                System.err.println("Error: arg[" + argIndex + "] must be a valid number, got: " + args[argIndex]);
-                System.exit(-1);
-            }
-        }
-        return maxRecordCount;
-    }
-
-    /**
-     * コマンドライン引数からreportFormatをパースする
-     *
-     * @param args           コマンドライン引数配列
-     * @param argIndex       解析する引数のインデックス
-     * @param defaultValue   デフォルト値
-     * @return パース済みのreportFormat（"text", "html", または "both"）
-     */
-    public static String parseReportFormat(String[] args, int argIndex, String defaultValue) {
-        String reportFormat = args.length > argIndex ? args[argIndex].toLowerCase() : defaultValue;
-        if (!reportFormat.equals("text") && !reportFormat.equals("html") && !reportFormat.equals("both")) {
-            System.err.println("Error: report format must be 'text', 'html', or 'both', got: " + reportFormat);
-            System.exit(-1);
-        }
-        return reportFormat;
-    }
 }

--- a/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
+++ b/src/main/java/lucene/gosen/wikipedia/report/ExecutionInfo.java
@@ -27,8 +27,6 @@ public class ExecutionInfo {
     private String dataSourcePath;  // XMLまたはParquetファイルのパス
     private String dataSourceType;  // "XML" または "Parquet"
     private int maxRecordCount;
-    private String reportFormat;
-    private String outputDirectory;
     private Date startTime;
     private Date endTime;
     private long durationMs;
@@ -91,22 +89,6 @@ public class ExecutionInfo {
 
     public void setMaxRecordCount(int maxRecordCount) {
         this.maxRecordCount = maxRecordCount;
-    }
-
-    public String getReportFormat() {
-        return reportFormat;
-    }
-
-    public void setReportFormat(String reportFormat) {
-        this.reportFormat = reportFormat;
-    }
-
-    public String getOutputDirectory() {
-        return outputDirectory;
-    }
-
-    public void setOutputDirectory(String outputDirectory) {
-        this.outputDirectory = outputDirectory;
     }
 
     public Date getStartTime() {


### PR DESCRIPTION
## Summary\n- remove unused ParserUtils#parseMaxRecordCount and ParserUtils#parseReportFormat\n- remove unused ExecutionInfo fields and accessors: eportFormat, outputDirectory\n- remove now-unused xecInfo.setReportFormat(...) assignment from ParserUtils#buildExecutionInfo\n\n## Why\n- simplifies maintenance by deleting dead code\n- removes System.exit usage from library utility code path\n- keeps runtime behavior unchanged because these members were not used\n\nCloses #36