### PR TITLE
Issue #46: common download helpers + SKIP_IF_VALID + EOL normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto eol=lf
+
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+*.jar binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.zip binary

--- a/src/main/java/lucene/gosen/wikipedia/DownloadUtils.java
+++ b/src/main/java/lucene/gosen/wikipedia/DownloadUtils.java
@@ -1,0 +1,48 @@
+package lucene.gosen.wikipedia;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+final class DownloadUtils {
+
+    private static final int BUFFER_SIZE = 65536;
+    private static final long PROGRESS_INTERVAL_MILLIS = 5000L;
+
+    private DownloadUtils() {
+    }
+
+    static void ensureDirectory(Path directory) throws IOException {
+        if (directory != null && Files.notExists(directory)) {
+            Files.createDirectories(directory);
+            System.out.println("Created directory: " + directory);
+        }
+    }
+
+    static void ensureParentDirectory(Path filePath) throws IOException {
+        ensureDirectory(filePath.getParent());
+    }
+
+    static long copyWithProgress(InputStream in, OutputStream out) throws IOException {
+        byte[] dataBuffer = new byte[BUFFER_SIZE];
+        int bytesRead;
+        long totalBytesRead = 0L;
+        long lastReportedTime = System.currentTimeMillis();
+
+        while ((bytesRead = in.read(dataBuffer)) != -1) {
+            out.write(dataBuffer, 0, bytesRead);
+            totalBytesRead += bytesRead;
+
+            long currentTime = System.currentTimeMillis();
+            if (currentTime - lastReportedTime > PROGRESS_INTERVAL_MILLIS) {
+                System.out.printf("Downloaded: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
+                lastReportedTime = currentTime;
+            }
+        }
+
+        System.out.printf("Download completed! Total size: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
+        return totalBytesRead;
+    }
+}

--- a/src/main/java/lucene/gosen/wikipedia/MavenJarDownloader.java
+++ b/src/main/java/lucene/gosen/wikipedia/MavenJarDownloader.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.Callable;
+import java.util.jar.JarFile;
 
 /**
  * Maven CentralからluceneとGosenのJARファイルをダウンロードするクラス
@@ -71,10 +72,7 @@ public class MavenJarDownloader implements Callable<Integer> {
      */
     public static void downloadLuceneGosenWithDependencies(String version, String destDir, String classifier) throws Exception {
         Path destPath = Paths.get(destDir);
-        if (Files.notExists(destPath)) {
-            Files.createDirectories(destPath);
-            System.out.println("Created directory: " + destPath.toAbsolutePath());
-        }
+        DownloadUtils.ensureDirectory(destPath);
 
         // 1. lucene-gosenをダウンロード
         System.out.println("\n=== Downloading lucene-gosen ===");
@@ -177,35 +175,31 @@ public class MavenJarDownloader implements Callable<Integer> {
     private static void downloadFile(String urlString, String destString) throws IOException {
         Path destPath = Paths.get(destString);
 
-        // 既に存在する場合はスキップ
+        // SKIP_IF_VALID: 有効なJARが既存なら再ダウンロードしない
         if (Files.exists(destPath)) {
-            System.out.println("File already exists, skipping: " + destPath.getFileName());
-            return;
+            if (isLikelyValidJar(destPath)) {
+                System.out.println("Valid jar already exists, skipping: " + destPath.getFileName());
+                return;
+            }
+            System.out.println("Existing jar is invalid, re-downloading: " + destPath.getFileName());
+            Files.delete(destPath);
         }
 
         System.out.println("Downloading from: " + urlString);
         System.out.println("To: " + destPath.toAbsolutePath());
 
         URL url = URI.create(urlString).toURL();
-        try (InputStream in = new BufferedInputStream(url.openStream());
+        try (BufferedInputStream in = new BufferedInputStream(url.openStream());
              FileOutputStream out = new FileOutputStream(destPath.toFile())) {
+            DownloadUtils.copyWithProgress(in, out);
+        }
+    }
 
-            byte[] dataBuffer = new byte[65536]; // 64KB buffer
-            int bytesRead;
-            long totalBytesRead = 0;
-            long lastReportedTime = System.currentTimeMillis();
-
-            while ((bytesRead = in.read(dataBuffer)) != -1) {
-                out.write(dataBuffer, 0, bytesRead);
-                totalBytesRead += bytesRead;
-
-                long currentTime = System.currentTimeMillis();
-                if (currentTime - lastReportedTime > 5000) { // 5秒ごとに進捗表示
-                    System.out.printf("Downloaded: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
-                    lastReportedTime = currentTime;
-                }
-            }
-            System.out.printf("Download completed! Total size: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
+    private static boolean isLikelyValidJar(Path path) {
+        try (JarFile ignored = new JarFile(path.toFile())) {
+            return true;
+        } catch (IOException e) {
+            return false;
         }
     }
 }

--- a/src/main/java/lucene/gosen/wikipedia/Wiki40bDownloader.java
+++ b/src/main/java/lucene/gosen/wikipedia/Wiki40bDownloader.java
@@ -99,10 +99,7 @@ public class Wiki40bDownloader implements Callable<Integer> {
      */
     public static void downloadSplit(Split split, String destDir) throws IOException {
         Path destPath = Paths.get(destDir);
-        if (Files.notExists(destPath)) {
-            Files.createDirectories(destPath);
-            System.out.println("Created directory: " + destPath);
-        }
+        DownloadUtils.ensureDirectory(destPath);
 
         String url = split.getUrl();
         String destFile = destDir + "/" + split.getFileName();
@@ -147,23 +144,7 @@ public class Wiki40bDownloader implements Callable<Integer> {
 
         try (InputStream in = new BufferedInputStream(connection.getInputStream());
              FileOutputStream out = new FileOutputStream(tempPath.toFile())) {
-
-            byte[] dataBuffer = new byte[65536]; // 64KB buffer
-            int bytesRead;
-            long totalBytesRead = 0;
-            long lastReportedTime = System.currentTimeMillis();
-
-            while ((bytesRead = in.read(dataBuffer)) != -1) {
-                out.write(dataBuffer, 0, bytesRead);
-                totalBytesRead += bytesRead;
-
-                long currentTime = System.currentTimeMillis();
-                if (currentTime - lastReportedTime > 5000) { // 5秒ごとに進捗表示
-                    System.out.printf("Downloaded: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
-                    lastReportedTime = currentTime;
-                }
-            }
-            System.out.printf("Download completed! Total size: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
+            DownloadUtils.copyWithProgress(in, out);
         } catch (FileNotFoundException e) {
             throw new IOException("Download returned no file content: " + urlString, e);
         } finally {

--- a/src/main/java/lucene/gosen/wikipedia/WikipediaDownloader.java
+++ b/src/main/java/lucene/gosen/wikipedia/WikipediaDownloader.java
@@ -4,10 +4,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
-import java.io.BufferedInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
@@ -51,35 +49,25 @@ public class WikipediaDownloader implements Callable<Integer> {
 
     public static void downloadFile(String urlString, String destString) throws IOException {
         Path destPath = Paths.get(destString);
-        Path parentDir = destPath.getParent();
-        if (parentDir != null && Files.notExists(parentDir)) {
-            Files.createDirectories(parentDir);
-            System.out.println("Created directory: " + parentDir);
+        DownloadUtils.ensureParentDirectory(destPath);
+
+        // SKIP_IF_VALID: サイズ0より大きい既存ファイルは有効とみなして再ダウンロードしない
+        if (Files.exists(destPath)) {
+            if (Files.size(destPath) > 0) {
+                System.out.println("Valid file already exists, skipping: " + destPath.getFileName());
+                return;
+            }
+            System.out.println("Existing file is empty, re-downloading: " + destPath.getFileName());
+            Files.delete(destPath);
         }
 
         System.out.println("Downloading from: " + urlString);
         System.out.println("To: " + destPath.toAbsolutePath());
 
         URL url = URI.create(urlString).toURL();
-        try (InputStream in = new BufferedInputStream(url.openStream());
+        try (var in = url.openStream();
              FileOutputStream out = new FileOutputStream(destPath.toFile())) {
-
-            byte[] dataBuffer = new byte[65536]; // 64KB buffer
-            int bytesRead;
-            long totalBytesRead = 0;
-            long lastReportedTime = System.currentTimeMillis();
-
-            while ((bytesRead = in.read(dataBuffer)) != -1) {
-                out.write(dataBuffer, 0, bytesRead);
-                totalBytesRead += bytesRead;
-
-                long currentTime = System.currentTimeMillis();
-                if (currentTime - lastReportedTime > 5000) { // 5秒ごとに進捗表示
-                    System.out.printf("Downloaded: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
-                    lastReportedTime = currentTime;
-                }
-            }
-            System.out.printf("Download completed! Total size: %.2f MB%n", totalBytesRead / (1024.0 * 1024.0));
+            DownloadUtils.copyWithProgress(in, out);
         }
     }
 }

--- a/src/test/java/lucene/gosen/wikipedia/DownloadUtilsTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/DownloadUtilsTest.java
@@ -1,0 +1,46 @@
+package lucene.gosen.wikipedia;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DownloadUtilsTest {
+
+    @Test
+    void testEnsureDirectoryCreatesMissingDirectory(@TempDir Path tempDir) throws IOException {
+        Path missing = tempDir.resolve("level1/level2");
+        DownloadUtils.ensureDirectory(missing);
+        assertTrue(Files.exists(missing));
+        assertTrue(Files.isDirectory(missing));
+    }
+
+    @Test
+    void testEnsureParentDirectoryCreatesMissingParent(@TempDir Path tempDir) throws IOException {
+        Path filePath = tempDir.resolve("a/b/c/file.txt");
+        DownloadUtils.ensureParentDirectory(filePath);
+        assertTrue(Files.exists(filePath.getParent()));
+        assertTrue(Files.isDirectory(filePath.getParent()));
+    }
+
+    @Test
+    void testCopyWithProgressCopiesAllBytes() throws IOException {
+        byte[] source = "copy-test-data".getBytes(StandardCharsets.UTF_8);
+        ByteArrayInputStream in = new ByteArrayInputStream(source);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        long copied = DownloadUtils.copyWithProgress(in, out);
+
+        assertEquals(source.length, copied);
+        assertArrayEquals(source, out.toByteArray());
+    }
+}

--- a/src/test/java/lucene/gosen/wikipedia/WikipediaDownloaderTest.java
+++ b/src/test/java/lucene/gosen/wikipedia/WikipediaDownloaderTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -108,5 +109,33 @@ class WikipediaDownloaderTest {
             assertTrue(Files.exists(destDir));
             assertTrue(Files.isDirectory(destDir));
         }
+    }
+
+    @Test
+    void testDownloadFileSkipsWhenValidFileExists(@TempDir Path tempDir) throws IOException {
+        Path source = tempDir.resolve("source.txt");
+        Files.writeString(source, "new-content", StandardCharsets.UTF_8);
+
+        Path destination = tempDir.resolve("destination.txt");
+        Files.writeString(destination, "existing-content", StandardCharsets.UTF_8);
+
+        WikipediaDownloader.downloadFile(source.toUri().toString(), destination.toString());
+
+        String actual = Files.readString(destination, StandardCharsets.UTF_8);
+        assertEquals("existing-content", actual);
+    }
+
+    @Test
+    void testDownloadFileRedownloadsWhenExistingFileIsEmpty(@TempDir Path tempDir) throws IOException {
+        Path source = tempDir.resolve("source.txt");
+        Files.writeString(source, "new-content", StandardCharsets.UTF_8);
+
+        Path destination = tempDir.resolve("destination.txt");
+        Files.writeString(destination, "", StandardCharsets.UTF_8);
+
+        WikipediaDownloader.downloadFile(source.toUri().toString(), destination.toString());
+
+        String actual = Files.readString(destination, StandardCharsets.UTF_8);
+        assertEquals("new-content", actual);
     }
 }


### PR DESCRIPTION
## Summary
- add `DownloadUtils` and centralize common download helpers:
  - `ensureDirectory(Path)`
  - `ensureParentDirectory(Path)`
  - `copyWithProgress(InputStream, OutputStream)`
- switch `WikipediaDownloader`, `MavenJarDownloader`, and `Wiki40bDownloader` to use shared helpers
- align downloader behavior with `SKIP_IF_VALID` policy
  - `WikipediaDownloader`: skip when existing file size > 0, redownload empty file
  - `MavenJarDownloader`: skip only when existing file is a valid JAR
- add/extend tests (`DownloadUtilsTest`, `WikipediaDownloaderTest`)
- add `.gitattributes` and normalize text EOL policy to LF (with CRLF exceptions for Windows scripts)

## Test
- `./gradlew test --tests "lucene.gosen.wikipedia.DownloadUtilsTest" --tests "lucene.gosen.wikipedia.WikipediaDownloaderTest" --tests "lucene.gosen.wikipedia.MavenJarDownloaderTest" --tests "lucene.gosen.wikipedia.Wiki40bDownloaderTest"`

Refs #46